### PR TITLE
editing

### DIFF
--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -3,14 +3,42 @@
 
   --spacing-unit: 5px;
 
+  /* markdown content */
   --md-paragraph-margin: 1rem 0;
   --md-list-margin: 0.55rem 0.25rem;
-  --md-content-max-width: 700px;
 
+  /* headings */
+  --h1-font-size: 36px;
+  --h1-line-height: 46px;
+  --h1-margin-top: var(--spacing-xxl);
+  --h1-margin-bottom: var(--spacing-base);
+
+  --h2-font-size: 30px;
+  --h2-line-height: 38px;
+  --h2-margin-top: var(--spacing-xl);
+  --h2-margin-bottom: var(--spacing-base);
+
+  --h3-font-size: 26px;
+  --h3-line-height: 34px;
+  --h3-margin-top: var(--spacing-lg);
+  --h3-margin-bottom: var(--spacing-sm);
+
+  --h4-font-size: 18px;
+  --h4-line-height: 30px;
+  --h4-margin-top: var(--spacing-md);
+  --h4-margin-bottom: var(--spacing-sm);
 
   --h5-font-size: 16px;
-  --h5-margin-top: var(--spacing-sm);
+  --h5-line-height: 16px;
+  --h5-margin-top: var(--spacing-md);
+  --h5-margin-bottom: var(--spacing-xs);
 
+  --h6-font-size: 14px;
+  --h6-line-height: 14px;
+  --h6-margin-top: var(--spacing-sm);
+  --h6-margin-bottom: var(--spacing-xs);
+
+  /* sidebar */
   --sidebar-width: 328px;
   --menu-item-label-gap: var(--spacing-xxs);
   --menu-item-nested-offset: var(--spacing-xs);

--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -1,3 +1,8 @@
+:root {
+  --font-family-base: 'Lato', sans-serif;
+  --font-weight-regular: 400;
+}
+
 :root .button-tone-brand {
   background-color: rgb(242, 129, 33);
   color: var(--text-color-on-color);

--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -1,13 +1,18 @@
+/* style reference: https://redocly.com/docs/realm/style/reference/css-variables */
+
 :root {
-  --font-weight-regular: 400;
+  --font-family-base: 'Red Hat Text', sans-serif;
 
   --spacing-unit: 5px;
 
-  /* markdown content */
+  /* markdown */
   --md-paragraph-margin: 1rem 0;
   --md-list-margin: 0.55rem 0.25rem;
+  --md-content-max-width: 700px;
 
   /* headings */
+  /* --heading-font-family: 'Lora', serif; */
+
   --h1-font-size: 36px;
   --h1-line-height: 46px;
   --h1-margin-top: var(--spacing-xxl);
@@ -18,7 +23,7 @@
   --h2-margin-top: var(--spacing-xl);
   --h2-margin-bottom: var(--spacing-base);
 
-  --h3-font-size: 26px;
+  --h3-font-size: 24px;
   --h3-line-height: 34px;
   --h3-margin-top: var(--spacing-lg);
   --h3-margin-bottom: var(--spacing-sm);
@@ -42,6 +47,11 @@
   --sidebar-width: 328px;
   --menu-item-label-gap: var(--spacing-xxs);
   --menu-item-nested-offset: var(--spacing-xs);
+
+  /* colors (light mode) */
+  --sidebar-bg-color: rgb(247, 247, 247);
+  --bg-color: var(--color-warm-grey-1);
+  --navbar-bg-color: white;
 }
 
 :root.dark {

--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -75,3 +75,7 @@
 li {
   margin: 0.4rem 0;
 }
+
+:root .card-variant-filled {
+  background-color: var(--sidebar-bg-color);
+}

--- a/@theme/styles.css
+++ b/@theme/styles.css
@@ -1,6 +1,27 @@
 :root {
-  --font-family-base: 'Lato', sans-serif;
   --font-weight-regular: 400;
+
+  --spacing-unit: 5px;
+
+  --md-paragraph-margin: 1rem 0;
+  --md-list-margin: 0.55rem 0.25rem;
+  --md-content-max-width: 700px;
+
+
+  --h5-font-size: 16px;
+  --h5-margin-top: var(--spacing-sm);
+
+  --sidebar-width: 328px;
+  --menu-item-label-gap: var(--spacing-xxs);
+  --menu-item-nested-offset: var(--spacing-xs);
+}
+
+:root.dark {
+  --bg-color: var(--color-warm-grey-1);
+  --sidebar-bg-color: var(--color-warm-grey-2);
+  --navbar-bg-color: black;
+  --footer-bg-color: black;
+  --text-color-primary: var(--color-warm-grey-10);
 }
 
 :root .button-tone-brand {
@@ -11,4 +32,8 @@
 :root.dark .button-tone-brand {
   background-color: rgb(242, 129, 33);
   color: #fff;
+}
+
+li {
+  margin: 0.4rem 0;
 }

--- a/_partials/aws/create-credentials.md
+++ b/_partials/aws/create-credentials.md
@@ -1,11 +1,11 @@
 1. Log in to your AWS account that was created in the previous step.
-2. Navigate to the Identity and Access Management (IAM) portion of the AWS console. [Here is a link](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/home).
-3. Navigate to the "Users" section of the IAM console. [Here is a link](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users).
+2. Navigate to the [Identity and Access Management (IAM)](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/home) portion of the AWS console.
+3. Navigate to the [Users](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users) section of the IAM console.
 4. Select "Create user".
 5. Name your user. For the purposes of these instructions, we'll call ours "{% $iam_username %}".
-    1. Leave the "Provide user access to the AWS Management Console" option unchecked. This user will only require programmatic access to AWS.
+    - Leave the "Provide user access to the AWS Management Console" option unchecked. This user will only require programmatic access to AWS.
 6. On the next step, select "Attach policies directly"
-    1. In the policies list, check the `AdministratorAccess` policy
+    - In the policies list, check the `AdministratorAccess` policy.
 7. Proceed to the "Review and create" step. Your user should look something like this:
 
 [ ![review and create user](/images/install-catena/review-and-create-user.png) ](/images/install-catena/review-and-create-user.png)
@@ -15,7 +15,11 @@
 10. Select "Security credentials"
 11. Under the "Access keys" section, select "Create access key"
 12. Select "Third-party service"
-    1. *Note: AWS will recommend an alternative option. For ease of use, we will ignore this for the time being. Select "I understand the above recommendation and want to proceed to create an access key"*
+    {% admonition type="info" %}
+    Note: AWS will recommend an alternative option. For ease, we will ignore this for the time being. Select "I understand the above recommendation and want to proceed to create an access key".
+    {% /admonition %}
 13. Proceed to the next step and set an optional description tag
 14. Create your access key
-15. **Make note of your "Access key" and "Secret access key". You will need them later**
+{% admonition type="warning" %}
+**Make note of your "Access key" and "Secret access key". You will need them later.**
+{% /admonition %}

--- a/_partials/aws/install-aws-cli.md
+++ b/_partials/aws/install-aws-cli.md
@@ -2,7 +2,7 @@ The AWS CLI is a tool that allows users to manage AWS resources through the comm
 
 1. To install the AWS CLI, refer to [their installation documentation](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
 2. Once the CLI is installed, add your credentials that you created earlier. We'll be adding them to a specific profile called "{% $profile_name %}", but you can use whatever profile name you'd like.
-    1. For a list of available regions you can provide when prompted for the default region, refer to [available regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions). We recommend using the same region your S3 bucket was created in.
+    - For a list of available regions you can provide when prompted for the default region, refer to [available regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions). We recommend using the same region your S3 bucket was created in.
 
 ```bash
 aws configure --profile {% $profile_name %}

--- a/_partials/install-catena/install-wsl.md
+++ b/_partials/install-catena/install-wsl.md
@@ -1,4 +1,4 @@
-Full instructions for installing WSL can be found in [these official Microsoft docs](https://learn.microsoft.com/en-us/windows/wsl/install), but we've included a condensed version below.
+Full instructions for installing WSL can be found in [these official Microsoft docs](https://learn.microsoft.com/en-us/windows/wsl/install), but we've included a condensed version here.
 
 1. Open PowerShell in **administrator** mode by right-clicking and selecting “Run as administrator”
 2. Install WSL (We recommend using the **Ubuntu 24.04 LTS** distro.)

--- a/_partials/install-catena/install-wsl.md
+++ b/_partials/install-catena/install-wsl.md
@@ -1,7 +1,7 @@
-Full instructions for installing WSL can be found in [these official Microsoft docs](https://learn.microsoft.com/en-us/windows/wsl/install), but a condensed version can be found below.
+Full instructions for installing WSL can be found in [these official Microsoft docs](https://learn.microsoft.com/en-us/windows/wsl/install), but we've included a condensed version below.
 
 1. Open PowerShell in **administrator** mode by right-clicking and selecting “Run as administrator”
-2. Install WSL (We recommend using the **Ubuntu 24.04 LTS** distro)
+2. Install WSL (We recommend using the **Ubuntu 24.04 LTS** distro.)
 
 ```bash
 wsl --install -d Ubuntu-24.04

--- a/_partials/install-catena/obtain-catena-source.md
+++ b/_partials/install-catena/obtain-catena-source.md
@@ -1,5 +1,5 @@
-### 1. Obtain Source
-Catena is distributed via Git. You must have Git installed. [Instructions for installing Git can be found here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
+### 1. Obtain Catena source code
+Catena is distributed via Git. [Instructions for installing Git can be found here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 To gain access to the [Catena Source](https://github.com/CatenaTools/catena-tools-core), please contact us to obtain a license. Once you have access, clone Catena to your machine.
 

--- a/_partials/matchmaking/engine-integration.md
+++ b/_partials/matchmaking/engine-integration.md
@@ -1,3 +1,3 @@
-This page is dedicated to explaining key concepts for matchmaking in Catena, utilizing AWS FlexMatch. If you are interested in how to integrate matchmaking within a particular game engine, refer to your engine's documentation.
+This page is dedicated to explaining key concepts for matchmaking in Catena, utilizing {% $implementation %}. If you are interested in how to integrate matchmaking within a particular game engine, refer to your engine's documentation.
 
 * [Unity - Matchmaking](/engines/unity/matchmaking/index.md)

--- a/_partials/matchmaking/tickets.md
+++ b/_partials/matchmaking/tickets.md
@@ -8,7 +8,7 @@ An `Entity` is a special Catena data type used for passing and storing dynamic d
 
 **Tickets** will be sorted into **queues** based on the `queue_name` that is provided in the **ticket**. This `queue_name` is a requirement.
 
-An example ticket, in it's simplest form, looks like this:
+An example ticket, in its simplest form, looks like this:
 
 ```json
 {

--- a/_partials/unity/matchmaking-configuring-the-catena-backend.md
+++ b/_partials/unity/matchmaking-configuring-the-catena-backend.md
@@ -1,7 +1,7 @@
 Before you integrate the matchmaker into your Unity game, you first need to configure the Catena Backend properly. This configuration will differ depending on the needs of your game. Refer to the [Catena Matchmaker documentation](/features/matchmaking/index.md) for more information.
 
-For ease of testing for a first time integration, we recommend starting with a simple matchmaking **queue** definition that only requires a single player to execute the full matchmaking loop. We'll call that **queue**, `solo`.
+For testing a first time integration, we recommend starting with a simple matchmaking **queue** definition that only requires a single player to execute the full matchmaking loop. We'll call that **queue** `solo`.
 
-We'll also set up a 1v1 **queue** to facilitate two players matchmaking together. We'll call this **queue**, `1v1`.
+We'll also set up a 1v1 **queue** to facilitate two players matchmaking together. We'll call this **queue** `1v1`.
 
 The matchmaking implementation we will use is the [Catena Matchmaker](/features/matchmaking/catena-matchmaker.md).

--- a/_partials/unity/running-catena-prereq.md
+++ b/_partials/unity/running-catena-prereq.md
@@ -1,1 +1,1 @@
-In order to use the Catena Unity SDK, you must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).
+In order to use the Catena Unity SDK, you must be [running Catena](../../installation/index.md), either locally or deployed elsewhere.

--- a/_partials/unity/running-catena-prereq.md
+++ b/_partials/unity/running-catena-prereq.md
@@ -1,0 +1,1 @@
+In order to use the Catena Unity SDK, you must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).

--- a/core/index.md
+++ b/core/index.md
@@ -1,6 +1,6 @@
 # Catena Core
 
-Catena Core is like the engine of Catena. It creates a consistent framework to operate and develop services, a core set of components and behaviors services can leverage for common tasks, and it's extensible design means it can be molded to support new features without re-architecting.
+Catena Core is like the engine of Catena. It creates a consistent framework to operate and develop services, a core set of components and behaviors services can leverage for common tasks, and its extensible design means it can be molded to support new features without re-architecting.
 
 ## Catena node architecture
 

--- a/dashboard/index.md
+++ b/dashboard/index.md
@@ -2,4 +2,10 @@
 
 Guides to running, using, and customizing the Catena dashboard.
 
-{% partial file="/_partials/coming-soon.md" /%}
+{% cards columns=2 %}
+  {% card title="Dashboard Setup" to="./setup.md" /%}
+{% /cards %}
+
+{% admonition type="info" %}
+    More guides coming soon!
+{% /admonition %}

--- a/engines/unity/authentication.md
+++ b/engines/unity/authentication.md
@@ -10,8 +10,8 @@ markdown:
 Configuring Catena authentication in your Unity project is estimated to take **<10 minutes**.
 
 ## Prerequisites
-* You must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).
-* You must have completed [the Unity Quickstart Guide](./quickstart.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
+* You must have completed [the Unity Quickstart Guide](./quickstart.md).
 
 ## Adding Authentication
 The first real call you'll want to make to Catena is authenticating a player to register a session. Catena supports a variety of authentication providers. For the purposes of this guide, we will be using our **UNSAFE** provider, which is used for development workflows.

--- a/engines/unity/authentication.md
+++ b/engines/unity/authentication.md
@@ -10,7 +10,7 @@ markdown:
 Configuring Catena authentication in your Unity project is estimated to take **<10 minutes**.
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](../../installation/index.md)
+* You must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).
 * You must have completed [the Unity Quickstart Guide](./quickstart.md)
 
 ## Adding Authentication

--- a/engines/unity/entitlements.md
+++ b/engines/unity/entitlements.md
@@ -7,7 +7,7 @@ markdown:
 # Unity - Entitlements
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](../../installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * You must have the entitlements service running, and have it configured with Items and Offers already set up. Instructions for doing so can be found here
 <!-- Add in this link when it exists: [Instructions for doing so can be found here](../../features/entitlements/index.md). -->
 * You must have completed [the Unity Quickstart Guide](./quickstart.md)

--- a/engines/unity/entitlements.md
+++ b/engines/unity/entitlements.md
@@ -10,22 +10,22 @@ markdown:
 * {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * You must have the entitlements service running, and have it configured with Items and Offers already set up. Instructions for doing so can be found here
 <!-- Add in this link when it exists: [Instructions for doing so can be found here](../../features/entitlements/index.md). -->
-* You must have completed [the Unity Quickstart Guide](./quickstart.md)
-* You must have completed [the Unity Authentication Guide](./authentication.md)
+* You must have completed [the Unity Quickstart Guide](./quickstart.md).
+* You must have completed [the Unity Authentication Guide](./authentication.md).
 
 ## Adding Entitlements
-The first step to adding entitlements in your project is to set up a method of logging in the player, and getting an account. Once the player is logged in, they should be ready to lookup entitlements.
+The first step to adding entitlements in your project is to set up a way for the player to log in and get an account. Once the player is logged in, they should be ready to lookup entitlements.
 
-Additionally, you must already have catalog items and offers set up in your database through admin endpoints - as you won't be able to create items or offers from the Unity client.
+Additionally, you must already have catalog items and offers set up in your database through admin endpoints, as you won't be able to create items or offers from the Unity client.
 
 For more information on Entitlements in Catena and the features available, refer to the entitlements documentation.
 <!-- Add in this link when it exists: [refer to the Entitlements documentation](../../features/entitlements/index.md). -->
 
 ### Client-Side Entitlements
 
-1. Reminder, if you have not yet completed the [Unity Quickstart Guide](./quickstart.md), and [the Unity Authentication Guide](./authentication.md) please do so now.
-2. Return to the scene created in the Unity Authentication Guide, which should already have `CatenaEntrypoint` and `CatenaPlayer`. We will henceforth refer to this as "your Scene".
-3. Create an empty `GameObject` in your Scene.
+1. Reminder: if you have not yet completed the [Unity Quickstart Guide](./quickstart.md) and [the Unity Authentication Guide](./authentication.md), please do so now.
+2. Return to the scene created in the Unity Authentication Guide, which should already have `CatenaEntrypoint` and `CatenaPlayer`. We will henceforth refer to this as "your scene".
+3. Create an empty `GameObject` in your scene.
     1. Rename this `GameObject` to `CatenaClientEntitlements`.
     2. Add the `CatenaClientEntitlementsManager` component to your `GameObject`.
 
@@ -33,7 +33,7 @@ For more information on Entitlements in Catena and the features available, refer
 The **Catena Client Entitlements Manager** component houses functionality for allowing a player to get the list of items that they have - both getting the full list of items, and polling for whether the player owns an individual item.
 {% /admonition %}
 
-4. Import the Catena Unity SDK to the Script you'd like to create parties from, if not already done, as well as `Catena.CatenaEntitlements`.
+4.  If you haven't already done so, add the following imports to the script you'd like to create entitlements from:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -41,7 +41,7 @@ using Catena.CatenaEntitlements;
 using CatenaUnitySDK;
 ```
 
-5. From the function you'd like to get the player's catalog from, write the following code.
+5. In the function you'll use to get the player's catalog, write the following code:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -59,9 +59,9 @@ catenaClientEntitlements.OnGetCatalog += (object sender, List<CatenaEntrypoint.P
 catenaClientEntitlements.UpdateCatalog();
 ```
 
-With the above code, you should now be able to get the list of items that the player owns. By calling `UpdateCatalog`, the `CatenaClientEntitlementsManager` will now have a cached version of the catalog, which you can access with either `GetCatalog` (which provides the full list of items) or `GetCatalogItem` (which returns a single item, given the item Id.)
+With this in place, you should now be able to get the list of items that the player owns. By calling `UpdateCatalog`, the `CatenaClientEntitlementsManager` will now have a cached version of the catalog, which you can access with either `GetCatalog` (which provides the full list of items) or `GetCatalogItem` (which returns a single item, given the item Id.)
 
-Additionally, if you wish to just check whether the player owns a single item, you can call `GetPlayerOwnsCatalogItem` - which will check Catena directly if the player owns an item, rather than checking the cached data. The following code is an example of this:
+Additionally, if you wish to just check whether the player owns a single item, you can call `GetPlayerOwnsCatalogItem` — which will check Catena directly if the player owns an item, rather than checking the cached data. The following code is an example of this:
 
 ```c
 var catenaClientEntitlements = FindObjectOfType<CatenaClientEntitlementsManager>();
@@ -87,9 +87,9 @@ catenaClientEntitlements.GetPlayerOwnsCatalogItem("sample-item-id");
 
 ### Server-Side Entitlements
 
-Some entitlements functionality can only be done on a trusted service, the most important of which being preparing and executing offers. A server will prepare offers for a player, then send that offer info to the player - the player then picks the offer that they would like, which is then executed by the server.
+Some entitlements functionality can only be done on a trusted service, most importantly preparing and executing offers. A server will prepare offers for a player, then send that offer info to the player. The player then picks the offer that they would like, which is then executed by the server.
 
-The following steps are for code that should only be executed on a dedicated server build, which needs to include a valid API Key. How that server gets the API key is up to you - the following steps are for creating and executing an offer on a dedicated server with an API key set up.
+The following steps are for code that should only be executed on a dedicated server build, which needs to include a valid [API Key](../../features/api-keys/). The following steps are for creating and executing an offer on a dedicated server with an API key set up.
 
 1. Create an empty `GameObject` in your Scene.
     1. Rename this `GameObject` to `CatenaServerEntitlements`.
@@ -99,7 +99,7 @@ The following steps are for code that should only be executed on a dedicated ser
 The **Catena Server Entitlements Manager** component houses functionality for a server to both to determine what items the players own, as well as preparing and executing offers on behalf of the player connected to the server.
 {% /admonition %}
 
-2. Import the Catena Unity SDK to the Script you'd like to create parties from, if not already done, as well as `Catena.CatenaEntitlements`.
+2.  If you haven't already done so, add the following imports to the script you'd like to create offers from:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -121,7 +121,7 @@ catenaServerEntitlements.OnOffersPrepared += (object sender, CatenaEntrypoint.Pr
 catenaServerEntitlements.PrepareOffersForProvider("account-id", EntitlementProvider.Unspecified, "USD");
 ```
 
-4. Add the following code for when receiving the desired offers from the user
+4. Add the following code for receiving the desired offers from the user:
 
 ```c
 var catenaServerEntitlements = FindObjectOfType<CatenaServerEntitlementsManager>();
@@ -135,6 +135,12 @@ catenaServerEntitlements.OnOfferExecuted += (object sender, CatenaEntrypoint.Exe
 catenaServerEntitlements.ExecutePreparedOffers("account-id", preparedOrdersWithQuantity);
 ```
 
-### Demo Example
+## Demo Example
 
-For an example of the entitlements functionality in action, check out the [Catena Galactic Kittens Demo](https://github.com/CatenaTools/catena-GalacticKittens-demo). In order to enable the entitlements functionality in the demo, you will need to go to `Project Settings > Player > Scripting Define Symbols` and add a defintion for `ENABLE_CATENA_ENTITLEMENTS`. The demo has functionality to list the items that the user owns, solely as a test functionality, can prepare and execute it's own offers from the menu. You will need to provide an API key to the demo for this to work.
+For an example of the entitlements functionality in action, check out the [Catena Galactic Kittens Demo](https://github.com/CatenaTools/catena-GalacticKittens-demo).
+
+In order to enable the entitlements functionality in the demo, go to `Project Settings > Player > Scripting Define Symbols` and add a defintion for `ENABLE_CATENA_ENTITLEMENTS`. The demo has functionality to list the items that the user owns, solely as a test functionality, can prepare and execute its own offers from the menu.
+
+{% admonition type="info" %}
+You will need to provide an API key to the demo for this to work.
+{% /admonition %}

--- a/engines/unity/index.md
+++ b/engines/unity/index.md
@@ -2,19 +2,16 @@
 
 The Catena Unity SDK provides an easy way to integrate Catena into your Unity project.
 
-## 1. Quickstart
-{% card title="Unity Quickstart" to="./quickstart.md" %}
-    Get started in just a few minutes
-{% /card %}
+{% cards columns=1 %}
+    {% card title="Unity Quickstart" to="./quickstart.md" %}
+        Get started in just a few minutes
+    {% /card %}
 
-## 2. Authentication
-{% partial file="/_partials/unity/authentication-card.md" /%}
+    {% partial file="/_partials/unity/authentication-card.md" /%}
 
-## 3. Matchmaking
-{% partial file="/_partials/unity/matchmaking-card.md" /%}
+    {% partial file="/_partials/unity/matchmaking-card.md" /%}
 
-## 4. Parties
-{% partial file="/_partials/unity/parties-card.md" /%}
+    {% partial file="/_partials/unity/parties-card.md" /%}
 
-## 5. Entitlements
-{% partial file="/_partials/unity/entitlements-card.md" /%}
+    {% partial file="/_partials/unity/entitlements-card.md" /%}
+{% /cards %}

--- a/engines/unity/matchmaking/game-servers.md
+++ b/engines/unity/matchmaking/game-servers.md
@@ -8,7 +8,7 @@ markdown:
 Matchmaking into dedicated game servers is necessary when your game requires a trusted authority to track game state during your moment to moment gameplay.
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](/installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * You must have completed the [Unity Authentication Guide](../authentication.md)
 
 ## Configuring The Catena Backend
@@ -207,7 +207,7 @@ catenaEntrypoint.CancelMatchmaking(ticketId);
 Configuring a practical example should take you **<30 minutes**.
 
 ### Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](/installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * Complete the [Mirror Networking Guide](../supplemental-materials/mirror.md)
   * _This guide shows you how to set up an networked game MVP in Unity in less than 10 minutes. **Mirror is not a requirement to use Catena Matchmaking, it is only used in these docs to show you a functional example of how to proceed after matchmaking**_
 

--- a/engines/unity/matchmaking/game-servers.md
+++ b/engines/unity/matchmaking/game-servers.md
@@ -110,7 +110,7 @@ void Awake()
 #if UNITY_SERVER
     // Start up game server, using whatever netcode solution you prefer
 
-    // Tell Catena we are ready for a matc 0.75rem 0h
+    // Tell Catena we are ready for a match
     _catenaSingleMatchGameServer = CatenaSingleMatchGameServer.Instance;
     _catenaSingleMatchGameServer.GetMatch();
 #endif

--- a/engines/unity/matchmaking/game-servers.md
+++ b/engines/unity/matchmaking/game-servers.md
@@ -5,11 +5,11 @@ markdown:
 ---
 
 # Unity - Matchmaking Into Dedicated Game Servers
-Matchmaking into dedicated game servers is necessary when your game requires a trusted authority to track game state during your moment to moment gameplay.
+Matchmaking into dedicated game servers is necessary when your game requires a trusted authority to track game state during your moment-to-moment gameplay.
 
 ## Prerequisites
 * {% partial file="/_partials/unity/running-catena-prereq.md" /%}
-* You must have completed the [Unity Authentication Guide](../authentication.md)
+* You must have completed the [Unity Authentication Guide](../authentication.md).
 
 ## Configuring The Catena Backend
 
@@ -51,7 +51,9 @@ Matchmaking into dedicated game servers is necessary when your game requires a t
 
 When matchmaking players into dedicated game servers, you will also need to configure the **Match Broker** in the Catena Backend. This configuration will differ depending on the needs of your game. Refer to the [Catena Match Broker documentation](/features/game-servers/index.md) for more information.
 
-For ease of testing for a first time integration, we recommend starting with a [CatenaLocalBareMetalAllocator](/features/game-servers/index.md#catenalocalbaremetalallocator) **Match Broker** configuration that will start and manage game server processes alongside the Catena backend. If you would like to provision game servers using another method, you may refer to the [available match broker allocator configuration options](/features/game-servers/index.md#available-configuration-options).
+For testing a first time integration, we recommend starting with a [CatenaLocalBareMetalAllocator](/features/game-servers/index.md#catenalocalbaremetalallocator) match broker configuration that will start and manage game server processes alongside the Catena backend.
+
+If you would like to provision game servers using another method, you may refer to the [available match broker allocator configuration options](/features/game-servers/index.md#available-configuration-options).
 
 ```json
 "Catena": {
@@ -89,16 +91,16 @@ For ease of testing for a first time integration, we recommend starting with a [
 {% admonition type="warning" %}
     If you have deployed Catena to Heroku, the `CatenaLocalBareMetalAllocator` is not supported. If you would like to run this allocator, refer to [Installation Options](/installation/index.md) to deploy Catena using a different configuration.
 
-    Please ensure your game server's executable is co-located with the Catena backend, or else it will not be able to run it.
+    Please ensure your game server's executable is co-located with the Catena backend, or else Catena will not be able to run it.
 {% /admonition %}
 
-# Configuring Your Dedicated Game Server
+## Configuring Your Dedicated Game Server
 Your game server will need to be configured to communicate with your running Catena backend.
 
 1. In the Scene that launches when the game server is run, add a new empty `GameObject` and call it `CatenaSingleMatchGameServer`.
 2. Add a component to that `GameObject`, selecting the `CatenaSingleMatchGameServer` script.
 
-In whatever your main script is to manage your Scene, such as `SceneManager.cs` if you are using the [Supplemental Material](/engines/unity/supplemental-materials/mirror.md) guide, add the following:
+In whichever script manages your Scene (such as `SceneManager.cs` if you are using the [Supplemental Material](/engines/unity/supplemental-materials/mirror.md) guide), add the following:
 
 ```c
 private CatenaSingleMatchGameServer _catenaSingleMatchGameServer;
@@ -108,15 +110,15 @@ void Awake()
 #if UNITY_SERVER
     // Start up game server, using whatever netcode solution you prefer
 
-    // Tell Catena we are ready for a match
+    // Tell Catena we are ready for a matc 0.75rem 0h
     _catenaSingleMatchGameServer = CatenaSingleMatchGameServer.Instance;
     _catenaSingleMatchGameServer.GetMatch();
 #endif
 }
 ```
 
-# Matchmaking A Player
-Reminder, if you have not yet completed the [Unity Authentication Guide](../authentication.md), please do so now. Once a player has authenticated against Catena and registered a session, they can then begin matchmaking.
+## Matchmaking a Player
+Reminder: if you have not yet completed the [Unity Authentication Guide](../authentication.md), please do so now. Once a player has authenticated against Catena and registered a session, they can then begin matchmaking.
 
 To initiate matchmaking, you first need to register callbacks:
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
@@ -216,7 +218,7 @@ Configuring a practical example should take you **<30 minutes**.
 2. Remove the `Network Manager HUD` from your `NetworkManager` object
 
 ### Add Matchmaking
-1. Replace the contents of your `SceneManager.cs` file with the below code
+1. Replace the contents of your `SceneManager.cs` file with the following code:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -474,15 +476,17 @@ public class SceneManager : MonoBehaviour
 }
 ```
 
-2. Build your game server
+2. Build your game server:
     1. In your Unity Editor, navigate to `File -> Build Profiles`
     2. Select "Windows Server"
     3. Select "Switch Platform"
     4. Select "Build"
     5. Note the full path of your server build executable, you will need this in the next step
-3. If you are running Catena locally, skip this step. If you have it deployed somewhere, you will need to copy your server binary and associated output to the same machine that Catena is running on
-4. Configure your running Catena instance using the [Configuring The Catena Backend](#configuring-the-catena-backend) documentation above
-    1. When you are configuring the match broker, configure the `Catena.MatchBroker.Allocators[0].Configuration.GameServerPath` to be the full path of your server executable
+3. _If you are running Catena locally, you can skip this step_. If you have Catena deployed somewhere, copy your server binary and associated output to the same machine that Catena is running on.
+4. Configure your running Catena instance using the [Configuring The Catena Backend](#configuring-the-catena-backend) documentation above.
+    {% admonition type="info" %}
+    When you are configuring the match broker, configure `Catena.MatchBroker.Allocators[0].Configuration.GameServerPath` to be the full path of your server executable.
+    {% /admonition %}
 5. In your Unity editor, navigate to `File -> Build Profiles`
 6. Select "Windows"
 7. Select "Switch Platform"

--- a/engines/unity/matchmaking/peer-to-peer.md
+++ b/engines/unity/matchmaking/peer-to-peer.md
@@ -10,7 +10,7 @@ Peer to peer matchmaking is the simplest configuration in which you can run the 
 
 ## Prerequisites
 * {% partial file="/_partials/unity/running-catena-prereq.md" /%}
-* You must have completed the [Unity Authentication Guide](../authentication.md)
+* You must have completed the [Unity Authentication Guide](../authentication.md).
 
 ## Configuring The Catena Backend
 {% partial file="/_partials/unity/matchmaking-configuring-the-catena-backend.md" /%}
@@ -48,10 +48,10 @@ Peer to peer matchmaking is the simplest configuration in which you can run the 
 }
 ```
 
-The `SimpleP2PMatchmakingHooks` **Custom Hook** is provided out of the box to bypass dedicated game server provisioning when matches are successfully made.
+The `SimpleP2PMatchmakingHooks` [custom hook](../../../features/matchmaking/catena-matchmaker-more.md#custom-hooks) is provided out of the box to bypass dedicated game server provisioning when matches are successfully made.
 
 ## Matchmaking A Player
-Reminder, if you have not yet completed the [Unity Authentication Guide](../authentication.md), please do so now. Once a player has authenticated against Catena and registered a session, they can then begin matchmaking.
+Reminder: if you have not yet completed the [Unity Authentication Guide](../authentication.md), please do so now. Once a player has authenticated against Catena and registered a session, they can then begin matchmaking.
 
 To initiate matchmaking, you first need to register callbacks:
 
@@ -139,7 +139,11 @@ Configuring a practical example should take you **<30 minutes**.
 ### Prerequisites
 * {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * Complete the [Mirror Networking Guide](../supplemental-materials/mirror.md)
-  * _This guide shows you how to set up an networked game MVP in Unity in less than 10 minutes. **Mirror is not a requirement to use Catena Matchmaking, it is only used in these docs to show you a functional example of how to proceed after matchmaking**_
+{% admonition type="info" %}
+This guide shows you how to set up an networked game MVP in Unity in less than 10 minutes.
+
+**Mirror is not a requirement to use Catena Matchmaking. It is only used in these docs to show you a functional example of how to proceed after matchmaking**.
+{% /admonition %}
 
 ### Configure Non-Matchmaking Portions
 1. Add authentication to the Mirror Sample by using the [Unity Authentication Guide](../authentication.md)
@@ -147,7 +151,7 @@ Configuring a practical example should take you **<30 minutes**.
 
 ### Add Peer to Peer Matchmaking
 1. Configure your running Catena instance using the [Configuring The Catena Backend](#configuring-the-catena-backend) documentation above
-2. Replace the contents of your `SceneManager.cs` file with the below code
+2. Replace the contents of your `SceneManager.cs` file with the following code:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c

--- a/engines/unity/matchmaking/peer-to-peer.md
+++ b/engines/unity/matchmaking/peer-to-peer.md
@@ -6,10 +6,10 @@ markdown:
 
 # Unity - Peer to Peer Matchmaking
 
-Peer to peer matchmaking is the simplest configuration you can run the Catena Matchmaker in. It is a good first step to get up and running, even if your game utilizes dedicated game servers. You can build on top of this implementation to add dedicated game server support.
+Peer to peer matchmaking is the simplest configuration in which you can run the Catena Matchmaker. It is a good first step to get up and running, even if your game utilizes dedicated game servers. You can build on top of this implementation to add dedicated game server support.
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](/installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * You must have completed the [Unity Authentication Guide](../authentication.md)
 
 ## Configuring The Catena Backend
@@ -137,7 +137,7 @@ catenaEntrypoint.CancelMatchmaking(ticketId);
 Configuring a practical example should take you **<30 minutes**.
 
 ### Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](/installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * Complete the [Mirror Networking Guide](../supplemental-materials/mirror.md)
   * _This guide shows you how to set up an networked game MVP in Unity in less than 10 minutes. **Mirror is not a requirement to use Catena Matchmaking, it is only used in these docs to show you a functional example of how to proceed after matchmaking**_
 

--- a/engines/unity/parties.md
+++ b/engines/unity/parties.md
@@ -8,27 +8,28 @@ markdown:
 
 ## Prerequisites
 * {% partial file="/_partials/unity/running-catena-prereq.md" /%}
-* You must have completed [the Unity Quickstart Guide](./quickstart.md)
-* You must have completed [the Unity Authentication Guide](./authentication.md)
+* You must have completed [the Unity Quickstart Guide](./quickstart.md).
+* You must have completed [the Unity Authentication Guide](./authentication.md).
 
 ## Adding Parties
-The first step to adding parties in your project is to set up a method of logging in the player, and getting an account. Once the player is logged in, they should be ready to create or join a party.
+The first step to adding parties in your project is to set up a way for the player to log in and get an account. Once the player is logged in, they should be ready to create or join a party.
 
 For more information on Parties in Catena and the features available, refer to the parties documentation.
 <!-- Add in this link when it exists: [refer to the Parties documentation](../../features/parties/index.md). -->
 
 ### Creating a party
 
-1. Reminder, if you have not yet completed the [Unity Quickstart Guide](./quickstart.md), and [the Unity Authentication Guide](./authentication.md) please do so now.
-2. Return to the scene created in the Unity Authentication Guide, which should already have `CatenaEntrypoint` and `CatenaPlayer`. We will henceforth refer to this as "your Scene".
-3. Create an empty `GameObject` in your Scene.
+1. Reminder: if you have not yet completed the [Unity Quickstart Guide](./quickstart.md) and [the Unity Authentication Guide](./authentication.md), please do so now.
+2. Return to the scene created in the Unity Authentication Guide, which should already have `CatenaEntrypoint` and `CatenaPlayer`. We will  refer to this as "your scene".
+3. Create an empty `GameObject` in your scene.
     1. Rename this `GameObject` to `CatenaParties`.
     2. Add the `CatenaPartiesManager` component to your `GameObject`.
 
-#### What Is The Catena Parties Manager?
-The **Catena Parties Manager** component houses functionality for operations related to parties. It's a way to more easily interface with the Catena Party endpoints, instead of using the **Catena Entrypoint** component directly.
+{% admonition type="info" name="What Is The Catena Parties Manager?" %}
+The **Catena Parties Manager** component houses functionality for operations related to parties. It's an easier way to interface with the Catena Party endpoints, instead of using the **Catena Entrypoint** component directly.
+{% /admonition %}
 
-4. Import the Catena Unity SDK to the Script you'd like to create parties from, if not already done, as well as `Catena.CatenaParties`.
+4. If you haven't already done so, add the following imports to the script you'd like to create parties from:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -36,7 +37,7 @@ using Catena.CatenaParties;
 using CatenaUnitySDK;
 ```
 
-5. From the function you'd like to make calls to Catena from, write the following code.
+5. In the function you'll use to make calls to Catena, write the following code:
 
 <!-- TODO (@HF): csharp does not appear to be supported. determine how to enable it for better syntax highlighting -->
 ```c
@@ -51,18 +52,23 @@ catenaParties.CreateParty();
 ```
 {% admonition type="warning" name="Account Needed"%}
 In order to create or join a party, the player must already be logged in to Catena, so you must check this before trying to create/join a party. There are a few ways to do this:
-* Make sure wherever you are trying to create a party from is called only after account login is completed.
+* Ensure the method that tries to create a party is only called after successful account login.
 * Have your script subscribe to `CatenaPlayer.OnAccountLoginComplete`, so it is informed when login is complete.
 * Check  `CatenaEntrypoint.HasAccount` before making any calls to the Parties manager.
 {% /admonition %}
-With the party now created, you are now able to send the invite code to other players so they may join the party (The invite code is included in the `PartyEventArgs.Party` provided by the `OnPartyJoin` event). By creating the party, you become the default party leader.
+With the party now created, you are now able to send the invite code to other players so they may join the party (The invite code is included in the `PartyEventArgs.Party` provided by the `OnPartyJoin` event.)
+
+{% admonition type="info" %}
+By creating the party, you become the default party leader.
+{% /admonition %}
+
 ### Joining a Party
 
 In addition to creating parties, you will need the ability for other players to join parties. This is done using the invite code included in the response data from creating a party.
 
 1. Create a `UI > Input Field-TextMeshPro` in your scene, and rename it to `Invite Code`
 2. Add a reference to the input field in whatever script you'd like to join parties from.
-3. From the script you'd like to join the party from, add the following code:
+3. In the script you'd like to join the party from, add the following code:
 
 ```c
 // Example of reference to input field
@@ -82,11 +88,11 @@ public void JoinParty()
 
 4. Call the `JoinParty` function from wherever you'd like, after the input code has already been entered. For example, you could create a button (`UI > Button-TextMeshPro`), then add an `OnClick` event subscriber that calls the `JoinParty` function when clicked.
 
-You should now have the functionality to both create or join a party - with the party data being sent with the `OnPartyJoin` event.
+You should now have the functionality to both create or join a party — with the party data being sent with the `OnPartyJoin` event.
 
 ### Leaving a Party
 
-To leave a party, whether the player has created their own party or joined another, all you need to do is add a call to `LeaveParty` in the `CatenaPartiesManager` to your script. Here is some example code:
+To leave a party, whether the player has created their own party or joined another, all you need to do is add a call to `LeaveParty` in the `CatenaPartiesManager` to your script. For example:
 
 ```c
 public void LeaveParty()
@@ -104,33 +110,65 @@ public void LeaveParty()
 }
 ```
 
-### Other Party functionality
+## Other Party Functionality
 
-In addition to joining and leaving parties, there are a few other functions that can be called to modify the party in various ways. Whenever a party is updated, the event `CatenaPartiesManager.OnPartyUpdate` will be invoked, and will contain the updated party data. `OnPartyUpdate` will be invoked in response to either the player attempting to make changes to the party, or if another player in the party makes changes - keeping you up to date with the latest party information.
+### Events
 
-#### Readying Up
+In addition to joining and leaving parties, there are a few other functions that can be called to modify the party.
+{% admonition type="info" %}
+Whenever a player makes changes to a party, the `CatenaPartiesManager.OnPartyUpdate` event will be invoked, and will contain the updated party data.
+{% /admonition %}
+`OnPartyUpdate` keeps you up to date with the latest party information.
 
-In some cases, it may be helpful to have players say when they are ready, for cases such as the party leader needing everyone to be ready before starting matchmaking. This ready status can then be checked for all party members, as a way to confirm when everyone is ready. In order for a party member to 'ready up' you can call `CatenaPartiesManager.ReadyUp(bool isReady)` - giving the argument True for readying up, and False to un-ready up.
+### Readying Up
+
+In some cases, it may be helpful to have players indicate when they are "ready". For example, the party leader may need everyone to be ready before starting matchmaking. 
+
+To "ready up" a party member, you can call `CatenaPartiesManager.ReadyUp(bool isReady)`, with the argument `True` for readying up, and `False` to un-ready up. This sets a status which can be checked to confirm whether a given party member is ready.
 
 You can get the ready status of a player through the party data that is returned when joining or updating a party.
 
-#### Leader Abilities
+### Leader Abilities
 
-The party leader has access to some functionality that the other players do not - such as kicking players, or promoting other players to leaders.
+The party leader has access to some functionality that the other players do not — such as kicking players, or promoting other players to leaders.
 
-- **To check the leader status of a player:** You can see if the current user is the leader via `CatenaPartiesManager.IsLeader()`, and otherwise check a player's leader status through the party data that is returned when joining or updating a party.
-- **To kick a player:** Add a call to `CatenaPartiesManager.KickPlayer(string playerId)`, with the argument being the player ID of the player you want to kick.
-- **To promote a player to be the leader:** Add a call to`CatenaPartiesManager.SetLeader(string playerId)`, with the argument being the player ID of the player you want to set as the new leader. (The player ID can be checked through the party data that is returned when joining/updating a party)
+#### Check the leader status of a player:
+You can see if the current user is the leader via `CatenaPartiesManager.IsLeader()`. You can also check a player's leader status through the party data that is returned when joining or updating a party.
 
-#### Party Metadata
+#### Kick a player:
+Add a call to `CatenaPartiesManager.KickPlayer(string playerId)`, passing the player ID of the player you want to kick.
 
-In addition to the ready status and leader status of a player, you can add other arbitrary metadata to both the party and individual players - allowing you to attach data and send that data to other members of the party. 
+#### Promote a player to be the leader:
+Add a call to`CatenaPartiesManager.SetLeader(string playerId)`, passing the player ID of the player you want to set as the new leader. (You can get the player ID from the party data that is returned when joining/updating a party.)
 
-- **To create metadata:** Add a call to `CatenaPartiesManager.CreateMetadata()` - you will need to provide a string as the key for the data, and an instance of `Catena.Groups.EntityMetadata`, as well as optionally the player ID of the player to add the metadata to. If a player ID is not given, then the metadata will be added to the overall party.
-- **To update metadata:** The requirements are similar to `CreateMetadata`, but this time calling `CatenaPartiesManager.UpdateMetadata()` - with the string being the key for the data you want to update, and providing the metadata as well as the optional player ID. You can also optionally add an `UpdateMetadataOperationType` as well, indicating whether you want to overwrite or append to the data - the default functionality being to overwrite.
-- **To delete metadata:** Add a call to `CatenaPartiesManager.DeleteMetadata()`, providing the key for the data you want to delete and the optional player ID. For deleting metadata, you can define a `DeleteJsonMetadataTypeType` (which defaults to the entire entry), and a list of json properties to remove, if not deleting the whole entry.
+### Party Metadata
 
-### Sample script
+In addition to the ready status and leader status of a player, you can add other arbitrary metadata to the party and to individual players. That data will be made available to all members of the party. 
+
+#### Create metadata:
+Make a call to `CatenaPartiesManager.CreateMetadata`. You will need to provide:
+- a string as the key for the data
+- an instance of `Catena.Groups.EntityMetadata`
+- (optionally) the player ID of the player to add the metadata to
+
+If a player ID is not given, then the metadata will be added to the overall party.
+
+#### Update metadata:
+Similarly, make a call to `CatenaPartiesManager.UpdateMetadata()`, providing:
+- the key for the data you want to update
+- the updated metadata
+- (optionally) the player ID
+
+You can also optionally add an `UpdateMetadataOperationType`, indicating whether you want to overwrite or append to the data. (Overwriting is the default.)
+
+#### Delete metadata:
+Make a call to `CatenaPartiesManager.DeleteMetadata()`, providing:
+- the key for the data you want to delete
+- (optionally) the player ID
+
+You can optionally define a `DeleteJsonMetadataTypeType` (which defaults to the entire entry), and a list of JSON properties to remove, if you don't want to delete the whole entry.
+
+## Sample script
 
 The following is an example script that includes public functions for all the different options for parties, with comments indicating when to call functions, and where to insert your own code, or calls to your own code.
 
@@ -239,6 +277,6 @@ public class PartyManager : MonoBehaviour
 }
 ```
 
-### Demo Example
+## Demo Example
 
 For an example of the party functionality in action, check out the [Catena Galactic Kittens Demo](https://github.com/CatenaTools/catena-GalacticKittens-demo). In order to enable the parties functionality in the demo, you will need to go to `Project Settings > Player > Scripting Define Symbols` and add a defintion for `ENABLE_CATENA_PARTIES`.

--- a/engines/unity/parties.md
+++ b/engines/unity/parties.md
@@ -7,7 +7,7 @@ markdown:
 # Unity - Parties
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](../../installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 * You must have completed [the Unity Quickstart Guide](./quickstart.md)
 * You must have completed [the Unity Authentication Guide](./authentication.md)
 

--- a/engines/unity/quickstart.md
+++ b/engines/unity/quickstart.md
@@ -4,7 +4,7 @@
 The initial integration of Catena to your Unity project is estimated to take **~10 minutes**.
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](../../installation/index.md)
+In order to use the Catena Unity SDK, you must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).
 
 ## Install the SDK
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
@@ -12,10 +12,16 @@ The initial integration of Catena to your Unity project is estimated to take **~
 The Unity SDK lives in Catena's source. It can be found at `catena-tools-core/CatenaUnitySDK/`.
 
 ### 2. Install SDK
-Copy the `catena-tools-core/CatenaUnitySDK/` directory into the `Assets/Scripts/` directory of your Unity project. You should now have the SDK at `<your_unity_project_path>/Assets/Scripts/CatenaUnitySDK/`.
+Copy the `catena-tools-core/CatenaUnitySDK/` directory into the `Assets/Scripts/` directory of your Unity project.
+
+{% admonition type="success" %}
+You should now have the SDK installed at `<your_unity_project_path>/Assets/Scripts/CatenaUnitySDK/`.
+{% /admonition %}
 
 {% admonition type="info" %}
-    For Unity versions **older** than *2020.1*, you will need to **remove** `CatenaUnitySDK/Runtime/Plugins/System.Runtime.CompilerServices.Unsafe.dll`. More information can be [found here](https://github.com/protocolbuffers/protobuf/issues/9618#issuecomment-1185348928).
+    For Unity versions **older** than *2020.1*, you will need to **remove** `CatenaUnitySDK/Runtime/Plugins/System.Runtime.CompilerServices.Unsafe.dll`.
+    
+    More information can be [found here](https://github.com/protocolbuffers/protobuf/issues/9618#issuecomment-1185348928).
 {% /admonition %}
 
 ## Hello World
@@ -24,10 +30,10 @@ Copy the `catena-tools-core/CatenaUnitySDK/` directory into the `Assets/Scripts/
 1. Create an empty `GameObject` in the Scene you would like to add Catena to.
 2. Rename this `GameObject` to `CatenaEntrypoint`.
 3. Add the `CatenaEntrypoint` component to your `GameObject`.
-4. Configure your `GameObject`
+4. Configure your `GameObject`:
     1. Configure the **Catena Endpoint URL** to point to your running instance of Catena. If you don't yet have a running instance of Catena, refer to the [How to Run Catena](../../installation/index.md) documentation.
-    2. You can skip configuring the **Catena Server Api Test Key** for the purposes of this quickstart guide.
-    3. Leave **Use Catena Data Cleanup** checked
+    2. You can skip configuring **Catena Server API Test Key** for the purposes of this guide.
+    3. Leave **Use Catena Data Cleanup** checked.
 
 #### What Is The Catena Entrypoint?
 The **Catena Entrypoint** component is a Singleton class that is used by other Catena components to communicate with the Catena backend.

--- a/engines/unity/quickstart.md
+++ b/engines/unity/quickstart.md
@@ -4,7 +4,7 @@
 The initial integration of Catena to your Unity project is estimated to take **~10 minutes**.
 
 ## Prerequisites
-In order to use the Catena Unity SDK, you must be running Catena, either locally or deployed elsewhere. [Instructions for doing so can be found here](../../installation/index.md).
+{% partial file="/_partials/unity/running-catena-prereq.md" /%}
 
 ## Install the SDK
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}

--- a/engines/unity/supplemental-materials/demo.md
+++ b/engines/unity/supplemental-materials/demo.md
@@ -11,7 +11,7 @@ As a companion to the Unity SDK, there is a [Catena Networking Demo](https://git
 The following sections are guides on how to use the demo, in order to demonstrate what integrating the SDK into a game project would look like.
 
 ## Prerequisites
-* You must be running Catena. It must be run locally or you must have it deployed somewhere. [Instructions for doing so can be found here](../../../installation/index.md)
+* {% partial file="/_partials/unity/running-catena-prereq.md" /%}
 
 ### Authentication & Login
 

--- a/features/accounts/index.md
+++ b/features/accounts/index.md
@@ -1,10 +1,16 @@
+---
+markdown:
+  toc: 
+    depth: 3
+---
+
 # Accounts
 
-Catena provides an accounts system that is designed for maximum flexibility. The rest of Catena is designed to not depend on catena's provided Account implementation, as a result, you can bring your own account implementation and swap it out for Catena's.
+Catena provides an accounts system that is designed for maximum flexibility. The rest of Catena is designed to _not_ depend on Catena's provided Accounts implementation; as a result, you can bring your own Accounts implementation and swap it out for Catena's.
 
 ## How does Catena define an account?
 
-The fields on an account are shown below, Catena primarily cares about the `account_id` and `display_name`, with the `auth_role` being the tie in to the authentication system when using Catena's provided accounts implementation.
+The fields on an account are shown below. Catena primarily cares about the `account_id` and `display_name`, with the `auth_role` being the tie in to the authentication system when using Catena's provided accounts implementation.
 
 | Field        | Type      | Description                                                                                                                         |
 |--------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
@@ -24,7 +30,7 @@ An account may have an arbitrary number of **metadata key-value pairs** associat
 ## Creating a new Account
 
 {% admonition type="info" %}
-The account creation flow ties in with the [Auth Framework](/core/auth/index.md), parts of this interface can be swapped out as-needed in order to support differing requirements.
+The account creation flow ties in with the [Auth Framework](/core/auth/index.md); parts of this interface can be swapped out as needed in order to support differing requirements.
 {% /admonition %}
 
 The diagram below shows the default out-of-the-box auth flow for Catena using Twitch Authentication. Each step is described in detail below.
@@ -43,11 +49,11 @@ The diagram below shows the default out-of-the-box auth flow for Catena using Tw
     Catena->>Client: CreateOrGetAccountFromTokenResponse
 ```
 
-### Create a new Session
+### Create a new session
 
 In a default configuration, prior to creating an account (or logging into an existing account) the user must first get a provider login session. This can be thought of as an identifier tied to a third party, like Discord or Twitch that uniquely identifies the user.
 
-After the user hits the LoginWithProvider api and completes the flow, they will have a session in the Catena backend. This session can then be used by the account service to create the user's account.
+After the user hits the `LoginWithProvider` API and completes the flow, they will have a session in the Catena backend. This session can then be used by the account service to create the user's account.
 
 {% openapi-code-sample operationId="catena.catena_authentication.CatenaAuthentication_LoginWithProvider" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
@@ -55,25 +61,26 @@ After the user hits the LoginWithProvider api and completes the flow, they will 
 
 After the user has created their login session, they can follow the steps below.
 
-When the `AccountsService` receives a `CreateOrGetAccountFromTokenRequest`, it will use the **provider account ID**, **provider display name**, and **provider type** stored in the `ProviderLoginPayload` in the session store created at login to query the accounts database for the existence of an account that has previously been created with the same provider information.
+When the `AccountsService` receives a `CreateOrGetAccountFromTokenRequest`, it will use the **provider account ID**, **provider display name**, and **provider type** stored in the `ProviderLoginPayload` in the [session store](../../core/auth/sessions.md#producing-a-session) created at login to query the accounts database. This checks whether an account has previously been created with the same provider information.
 
 If such an account exists, the handler for `CreateOrGetAccountFromToken` will return the account in a `CreateOrGetAccountFromTokenResponse`. Additionally, it will update the user's session to reference this account.
 
-Otherwise, an account with this provider information will be created, being assigned the role of `user` by default, its base-64 representation will similarly be added to the session store, and it will be returned in a `CreateOrGetAccountFromTokenResponse` by the method handler.
+Otherwise, an account with this provider information will be created, with the role of `user` by default. Its base-64 representation will be added to the session store, and it will be returned in a `CreateOrGetAccountFromTokenResponse` by the method handler.
 
 {% openapi-code-sample operationId="catena.catena_accounts.CatenaAccounts_CreateOrGetAccountFromToken" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
-### Fetching an existing account by ID & updating an account
+## Fetching an existing account by ID
 
 The Catena `AccountsService` supports fetching an existing account by its ID via `GetAccountById`.
 
 {% openapi-code-sample operationId="catena.catena_accounts.CatenaAccounts_GetAccountById" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
+## Updating an Account
 
-### Updating an Account
-
-The `AccountsService` also supports updating an account - specifically its **display name** and **associated metadata** - via `UpdateAccount`.
+The `AccountsService` also supports updating an account — specifically its **display name** and **associated metadata** — via `UpdateAccount`.
 
 {% openapi-code-sample operationId="catena.catena_accounts.CatenaAccounts_UpdateAccount" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
-**Note: This RPC facilitates account updates via `google.protobuf.FieldMasks` meaning that only the data specified in the update request will be overwritten. The rest of the account’s data will remain unchanged.**
+{% admonition type="info" %}
+**Note:** This RPC facilitates account updates via `google.protobuf.FieldMasks`, meaning that only the data specified in the update request will be overwritten. The rest of the account’s data will remain unchanged.
+{% /admonition %}

--- a/features/api-keys/index.md
+++ b/features/api-keys/index.md
@@ -11,7 +11,9 @@ Creating a new API key may be done in the admin dashboard or by calling `AdminCr
 In order to create an API key, at least one policy must be available (see [Managing policies](#managing-policies)).
 {% /admonition %}
 
-Policies are associated with keys via unique IDs. When creating an API key in the dashboard, a dropdown list of the currently available policies will be displayed. (This list can also be obtained by calling `AdminGetApiKeyPolicies`.)
+Policies are associated with keys via unique policy IDs. When creating an API key in the dashboard, a dropdown list of the currently available policies will be displayed. This list can also be obtained by calling `AdminGetApiKeyPolicies`:
+
+{% openapi-code-sample operationId="catena.catena_api_keys.CatenaApiKeys_AdminGetApiKeyPolicies" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
 ## Update or delete API keys
 
@@ -55,7 +57,9 @@ Permissions are defined in the code for each service. More information can be [f
 You can create, update, and delete policies in the admin dashboard (or by directly calling the related [RPCs](../../apis/catena-tools-core/catenaapikeys)).
 
 When you create a policy, you will be prompted for a unique policy name, and a list of permissions to associate with that policy. On the dashboard, the list of
-available permissions will be displayed for you. (You can also obtain them by calling `AdminGetApiKeyPermissions`.)
+available permissions will be displayed for you. You can also obtain them by calling `AdminGetApiKeyPermissions`:
+
+{% openapi-code-sample operationId="catena.catena_api_keys.CatenaApiKeys_AdminGetApiKeyPermissions" descriptionFile="../../apis/catena-tools-core.yaml" /%}
 
 Just as changing the policy on an API key will immediately change its permissions, changing the permissions on a policy will immediately impact all API keys
 currently using that policy.

--- a/features/authentication/index.md
+++ b/features/authentication/index.md
@@ -4,7 +4,7 @@ markdown:
     depth: 3
 ---
 
-<sup>_If you would like to learn more about the general concept of Authentication, you can refer to our [Building a Multiplayer Backend: Authentication](https://blog.catenatools.com/building-a-multiplayer-backend-authentication/) blog post._</sup>
+_If you would like to learn more about the general concept of Authentication, you can refer to our [Building a Multiplayer Backend: Authentication](https://blog.catenatools.com/building-a-multiplayer-backend-authentication/) blog post._
 
 # Authentication
 Catena supports a variety of Authentication methods designed for games of all types. This feature authenticates players using a specific identifier or third-party service, registering a session with Catena upon login.
@@ -19,11 +19,13 @@ This page is dedicated to explaining key concepts for authentication with Catena
 Catena provides two types of authentication: **UNSAFE** and **PLATFORM**. These each use the same API, for simplicity's sake.
 
 ### Unsafe Login
-**UNSAFE** login is designed to provide a low friction method for authenticating against Catena in development environments. This is done by specifying the `PROVIDER_UNSAFE` in your authentication request and providing a username formatted with the `test` prefix, followed by two numbers. For example: `test01`
+**UNSAFE** login is designed to provide a low friction method for authenticating against Catena in development environments. This is done by specifying `PROVIDER_UNSAFE` in your authentication request and providing a username formatted with the `test` prefix, followed by two numbers (for example: `test01`).
 
 To authenticate with an unsafe login, refer to the following code samples.
 
-_Note: A successful authentication request will return an empty response body. The `catena-session-id` response header is what we're looking for here._
+{% admonition type="info" %}
+**Note**: A successful authentication request will return an empty response body. The `catena-session-id` response header is what we're looking for here.
+{% /admonition %}
 
 #### Code Sample
 {% openapi-code-sample operationId="catena.catena_authentication.CatenaAuthentication_LoginWithProvider" descriptionFile="../../apis/catena-tools-core.yaml" /%}
@@ -38,15 +40,15 @@ _Note: A successful authentication request will return an empty response body. T
 
 ### How Catena Authentication Works
 
-#### Creating a Session
+This section delves into how the Catena Authentication process works under the hood. Unless you are inspecting or modifying Catena source code, you are not required to understand its inner workings.
 
-This section is for if you are interested in how the Catena Authentication process works under the hood. Unless you are inspecting our modifying Catena source code, you are not required to understand its inner workings.
+#### Creating a Session
 
 The `AuthenticationService` is responsible for handling login requests from client applications sent via [LoginWithProvider](../../apis/catena-tools-core.yaml#operation/catena.catena_authentication.catenaauthentication_loginwithprovider).
 
 Depending on the `provider` that is passed, the appropriate `IAuthValidator` is selected to validate the provided credentials. There are many auth validators to provide multiple methods for authenticating with Catena.
 
-Upon successfully validating the credentials, we create a session. This session is stored either in **SQLite** or **Redis** depending on the `Catena.SessionStore.SessionProvider` that is configured in your appsettings file.
+Upon successfully validating the credentials, we create a session. This session is stored in either **SQLite** or **Redis** depending on the `Catena.SessionStore.SessionProvider` that is configured in your `appsettings` file.
 
 This session ID is returned to the client application in the response headers, as `catena-session-id`. The client is expected to cache this value, using it for subsequent requests to Catena.
 

--- a/features/fleet-management/match-broker-allocators.md
+++ b/features/fleet-management/match-broker-allocators.md
@@ -2,9 +2,9 @@
 
 A list of the available Catena Match Broker allocators and their configurations.
 
-## CatenaLocalBareMetalAllocator
+## Local Baremetal Allocator
 
-The local baremetal allocator can start and manage game server processes alongside the Catena backend. It is great for early development and testing locally or on a cloud machine with the capacity to run one or more game server(s).
+The `CatenaLocalBareMetalAllocator` can start and manage game server processes alongside the Catena backend. It is great for early development and testing locally or on a cloud machine with the capacity to run one or more game server(s).
 
 It is necessary to configure the full path to the game server executable and any arguments necessary to start with the correct options/map/configuration/etc.
 
@@ -32,11 +32,11 @@ If the game server takes longer than 30 seconds to start up and begin fetching m
 }
 ```
 
-## CatenaGameLiftAllocator
+## GameLift Allocator
 
-The GameLift allocator handles several aspects of Amazon GameLift:
+The `CatenaGameLiftAllocator` handles several aspects of Amazon GameLift:
 
-For game servers which already implement support for GameLift it can proxy Catena matches into GameLift game sessions (when `ProxyMatchesToGameLift` is enabled). `ProxyMatchesToGameLift` should be disabled for game servers which implement the Catena (Server-Manager.md) APIs.
+For game servers that already implement support for GameLift, it can proxy Catena matches into GameLift game sessions (when `ProxyMatchesToGameLift` is enabled). `ProxyMatchesToGameLift` should be disabled for game servers that implement the Catena (Server-Manager.md) APIs.
 
 If enabled by `AllowFleetGrowth`, the allocator can automatically increase the maximum size of the GameLift fleet if necessary to support the game volume. This allocator will not decrease the maximum fleet size.
 
@@ -44,7 +44,7 @@ If enabled by `AllowFleetGrowth`, the allocator can automatically increase the m
 When using the Catena [Server Manager](server-manager.md) APIs to fetch matches and GameLift fleet auto-scaling, it is not necessary to use this allocator unless you want to automatically increase the maximum fleet size.
 {% /admonition %}
 
-It is suggested that `ReadyDeadlineSeconds` be set to the time required for the GameLift auto-scaler to start an additional game server and for that game server to start requesting matches which may total several minutes.
+It is suggested that `ReadyDeadlineSeconds` be set to the time required for the GameLift auto-scaler to start an additional game server and for that game server to start requesting matches that may total several minutes.
 
 ```json
 "MatchBroker": {
@@ -66,9 +66,9 @@ It is suggested that `ReadyDeadlineSeconds` be set to the time required for the 
 }
 ```
 
-## CatenaEc2DirectAllocator
+## EC2 Direct Allocator
 
-The EC2 direct allocator can start and manage game servers by starting and terminating AWS EC2 instances.
+The `CatenaEc2DirectAllocator` can start and manage game servers by starting and terminating AWS EC2 instances.
 
 It is necessary to configure the profile, region, and template ID to use this allocator. This allocator does not interact with or start game server processes directly, so it is necessary to [package the game server in an AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html#creating-an-ami).
 

--- a/features/fleet-management/server-manager.md
+++ b/features/fleet-management/server-manager.md
@@ -8,8 +8,8 @@ The default Catena server manager is contained within the [default match broker]
 
 ## Allocators
 
-Allocators utilize a simple interface that a server manager can use to allocate or deallocate game servers as necessary
-on a particular platform or provider. Examples may include a local process allocator, a docker container allocator, or a
+Allocators expose a simple interface that a server manager can use to allocate or deallocate game servers as needed,
+in compatibility with a particular platform or provider. Examples may include a local process allocator, a Docker container allocator, or a
 Multiplay allocator. Other components, such as an admin dashboard, may also be able to utilize allocators directly.
 
 {% admonition type="info" %}
@@ -41,9 +41,9 @@ sequenceDiagram
 An example of the simple flow, running a single match, is included in
 a [mock game server script](https://github.com/CatenaTools/catena-tools-core/blob/main/mocks/gameserver/gameserver.py).
 
-### API reference {collapsible="true"}
+### API reference
 
-<api-doc openapi-path="../apispec/openapi/api/v1/catena_server_manager.swagger.json"></api-doc>
+See the [Catena Server Manager API documentation](../../apis/catena-tools-core/catenaservermanager) for all the available RPCs.
 
 ### `RequestMatch`
 
@@ -63,8 +63,8 @@ A future extension of the messages may allow for any/all the following:
 #### Requirements filter
 
 A game server can use a requirements filter to ensure it will only receive a match it can run. The requirements filter
-can reference any of the fields that are used within the Catena backend or any match or player properties sent by
-clients or developed during matchmaking. For example a game server may already have a map loaded and may only request
+can reference any of the fields that are used within the Catena backend, or any match or player properties sent by
+clients or developed during matchmaking. For example, a game server may already have a map loaded and may only request
 matches that require that map:
 
 ```C#
@@ -87,7 +87,7 @@ connection details for a match, the server is truly ready.
 When calling `MatchReady()`, the game server includes a generic connection string that is meaningful to clients; it is
 simply passed onto clients by the broker. The connection string may be a hostname and port, a URI, or contain extra
 metadata/extensions that will be meaningful or important to clients to connect to the server (such as a per game server
-key). It is included in each MatchReady request since it may be different for each match, particularly if a game server
+key). It is included in each MatchReady request, since it may be different for each match, particularly if a game server
 can run multiple matches in parallel or there is some additional metadata per match.
 
 ### `EndMatch`
@@ -101,7 +101,9 @@ manager hitting timeouts before cleaning up tracking of servers, making it less 
 
 Some game server request or response messages can contain hints. These hints are entirely optional but may make certain
 arrangements more efficient. Hints are predefined flags, shared across the server manager API, which may also be
-combined with each other. Hints may be sent with a request or response but interpretation is up the backend/SDK
+combined with each other.
+
+Hints may be sent with a request or response, but interpretation is dependent on the backend/SDK
 implementation, situation, and message type. Hints may be ignored when they are not supported or are not
 relevant to the situation or message type.
 
@@ -113,8 +115,8 @@ correctly.
 For example, the Catena match broker does not assume a game server exits after it calls `EndMatch`; it continues to
 track that server as available in case it can run another match, backfill itself, etc. However, if a game server _does_
 exit after `EndMatch`, then the broker may wait to start a new game server when a new match arrives, believing there is
-an idle game server that will soon call `RequestMatch`. After a delay, the match broker will identify the new match has
-not been picked up, more capacity is required, and it will start a new game server.
+an idle game server that will soon call `RequestMatch`. After a delay, the match broker will identify that the new match has
+not been picked up, and conclude that more capacity is required, so it will start a new game server.
 
 This inefficiency/delay can be avoided if the game server adds `HintFlag.Shutdown` to the hints in its `EndMatch`
 request when it knows it will exit afterward. The Catena match broker will immediately stop tracking the game server and
@@ -124,7 +126,17 @@ avoid unnecessary delays when the next new match arrives.
 
 These hints are implemented in the Catena [match broker](match-broker.md).
 
-Shutdown
-: This flag indicates to the backend that the game server will shut down after it receives a response to `EndMatch`.
-: This flag indicates to the game server that the backend would like it to shut down after it receives a response
-to `EndMatch`.
+<!-- TODO: fill in descriptions for flags -->
+
+Shutdown: This flag indicates to the backend that the game server will shut down after it receives a response to `EndMatch`.
+
+```protobuf
+enum HintFlag {
+    HINT_FLAG_NO_HINT_FLAGS = 0x00; // No flags - either unspecified or empty
+    HINT_FLAG_SHUTDOWN = 0x01; // Flag indicating a component will shutdown or should shut down if it can
+    HINT_FLAG_WILLING_TO_WAIT = 0x02; // Flag indicating a component is willing to wait a "long time" for a response to the request.
+    HINT_FLAG_WILLING_TO_SHUTDOWN = 0x04; // Flag indicating a component is willing to shutdown if a shutdown is requested
+    HINT_FLAG_FULL = 0x08; // Flag indicating a component will cease making requests for additional matches
+    HINT_FLAG_NOT_FULL = 0x10; // Flag indicating a component will begin making requests for additional matches
+}
+```

--- a/features/game-servers/index.md
+++ b/features/game-servers/index.md
@@ -54,11 +54,15 @@ sequenceDiagram
     SM-->>GS: EndMatchResponse
 ```
 
-## Configuring The Catena Match Broker
-The Catena Match Broker is configured using appsettings files in `catena-tools-core`.
+## Configuring The Match Broker
+
+The Catena Match Broker is configured using `appsettings` files in `catena-tools-core`.
 
 ### Basic Example
-_Note: This example does not include any **Allocators**, and therefore won't provision any servers. To view available **Allocator** configurations, see the [Available Configuration Options](#available-configuration-options) below._
+
+{% admonition type="info" %}
+Note: This example does not include any **Allocators**, and therefore won't provision any servers. To view available **Allocator** configurations, see the [Available Configuration Options](#available-configuration-options) below.
+{% /admonition %}
 
 ```json
 {
@@ -81,7 +85,7 @@ _Note: This example does not include any **Allocators**, and therefore won't pro
 ### Available Configuration Options
 Let's take a look at all the available properties in the `MatchBroker` config.
 
-| Property | Definition |
+| <div style="width:180px">Property</div> | Definition |
 |-|-|
 | `FastSchedule` | Options: `0`, `1`, `2`. Whether to allocate a server as soon as a new match arrives, if necessary. Reduces latency but potentially increases idle server overhead. This must be disabled when utilizing **backfilling**.<br/>If `0` is configured, fast scheduling will be disabled.<br/>If `1` is configured, running game servers that are able to support a match will be assigned before spinning up a new server.<br/>If `2` is configured, a new game server will be provisioned for every match no matter what. |
 | `ServerMaxLifetimeMinutes` | The maximum amount of time a game server process is expected to be extant.<br/>If this timer is hit, the Match Broker will be considered unusable and deallocated. |
@@ -97,7 +101,7 @@ Let's take a look at all the available properties in the `MatchBroker` config.
 
 Let's take a look at all the available properties in the `Allocators` config within the `MatchBroker` config.
 
-| Property | Definition |
+| <div style="width:160px">Property</div> | Definition |
 |-|-|
 | `Allocator` | The class name of the allocator |
 | `AllocatorDescription` | A human readable name or description of the allocator to differentiate it when multiple instances of an allocator are used. Defaults to the class name of the allocator if unset. |
@@ -136,7 +140,7 @@ The `CatenaLocalBareMetalAllocator` can start and manage game server processes a
 ...
 ```
 
-| Property | Definition |
+| <div style="width:150px">Property</div> | Definition |
 |-|-|
 | `GameServerPath` | The full path to your game server executable |
 | `GameServerArguments` | Command-line arguments to supply to the game server executable |
@@ -148,8 +152,14 @@ The `CatenaLocalBareMetalAllocator` can start and manage game server processes a
 #### CatenaEc2DirectAllocator
 {% partial file="/_partials/coming-soon.md" /%}
 
-#### CatenaGameLiftAllocator
-{% partial file="/_partials/coming-soon.md" /%}
+##### CatenaEc2DirectAllocator
 
-#### CatenaManagedHostAllocator
+See the [match broker allocators documentation](../fleet-management/match-broker-allocators.md#ec2-direct-allocator).
+
+##### CatenaGameLiftAllocator
+
+See the [match broker allocators documentation](../fleet-management/match-broker-allocators.md#gamelift-allocator).
+
+##### CatenaManagedHostAllocator
+
 {% partial file="/_partials/coming-soon.md" /%}

--- a/features/matchmaking/aws-flex-match.md
+++ b/features/matchmaking/aws-flex-match.md
@@ -12,9 +12,10 @@ If you would like to learn more about how Catena handles dedicated game servers,
 
 ## Engine Integration
 
-{% partial file="/_partials/matchmaking/engine-integration.md" /%}
+{% partial file="/_partials/matchmaking/engine-integration.md" variables={implementation: "AWS FlexMatch" } /%}
 
 ## What is AWS FlexMatch?
+
 [AWS FlexMatch](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-intro.html), also known as "Amazon GameLift Servers FlexMatch" is Amazon's offering for matchmaking players.
 
 ## Getting Started
@@ -27,7 +28,7 @@ To configure FlexMatch, you will also need to clone Catena's Infrastructure as C
 git clone git@github.com:CatenaTools/infrastructure.git
 ```
 
-### 2. Prep Work
+### 2. Preparations
 
 #### 2a. Create an AWS Account
 {% partial file="/_partials/aws/create-an-aws-account.md" /%}

--- a/features/matchmaking/catena-matchmaker.md
+++ b/features/matchmaking/catena-matchmaker.md
@@ -24,7 +24,7 @@ _Some additional details are found in a [previous version of this page](catena-m
 The Catena Matchmaker utilizes separate **queues** to partition tickets. These **queues** act like mini-matchmakers, supporting many different game types and matchmaking needs.
 
 * You may configure one or many **queues**, depending on the needs of your game.
-* Each **queue** can have it's own rules for match sizes, teams, **matchmaking strategies** (the algorithm used to make matches), or other custom requirements.
+* Each **queue** can have its own rules for match sizes, teams, **matchmaking strategies** (the algorithm used to make matches), or other custom requirements.
 * **Matchmaking tickets** are never moved between **queues** and are never matched with other **matchmaking tickets** from other **queues**.
 * The Catena Matchmaker will assign each **matchmaking ticket** to a **queue** based on the metadata it contains.
 
@@ -111,7 +111,7 @@ Let's take a look at all the available properties in the `Matchmaker` config.
 | <div style="width:190px">Property</div> | Definition |
 |-|-|
 | `MatchmakingQueues` | The **queues** that **tickets** can be added to |
-| `StatusExpirationMinutes` | Time before a matchmaking status is considered expired. Tickets that have successfully made a match or have expired are retained for this amount of time for observability purposes, or if a game client is not subscribed to events and prefers to poll the matchmaker for it's ticket's status |
+| `StatusExpirationMinutes` | Time before a matchmaking status is considered expired. Tickets that have successfully made a match or have expired are retained for this amount of time for observability purposes, or if a game client is not subscribed to events and prefers to poll the matchmaker for its ticket's status |
 | `CustomHooks` | Name of a **custom hook** class to use for all **queues** |
 
 Each **queue** defined with `MatchmakingQueues` will have its own properties.

--- a/features/matchmaking/catena-matchmaker.md
+++ b/features/matchmaking/catena-matchmaker.md
@@ -9,11 +9,11 @@ The Catena Matchmaker is responsible for grouping players or parties together to
 
 It is _not_ responsible for assigning dedicated game servers or fleet management. It is also not responsible for handling backfill. If you would like to learn more about how Catena handles dedicated game servers or backfill, refer to the [Match Broker](../game-servers/index.md) documentation.
 
-_Some details are found in a [previous version of this page](catena-matchmaker-more.md)_
+_Some additional details are found in a [previous version of this page](catena-matchmaker-more.md)_
 
 ## Engine Integration
 
-{% partial file="/_partials/matchmaking/engine-integration.md" /%}
+{% partial file="/_partials/matchmaking/engine-integration.md" variables={implementation: "the Catena Matchmaker"} /%}
 
 ## How The Matchmaker Works
 
@@ -108,7 +108,7 @@ How these **queues** are utilized by your game is up to you, but a few examples 
 
 Let's take a look at all the available properties in the `Matchmaker` config.
 
-| Property | Definition |
+| <div style="width:190px">Property</div> | Definition |
 |-|-|
 | `MatchmakingQueues` | The **queues** that **tickets** can be added to |
 | `StatusExpirationMinutes` | Time before a matchmaking status is considered expired. Tickets that have successfully made a match or have expired are retained for this amount of time for observability purposes, or if a game client is not subscribed to events and prefers to poll the matchmaker for it's ticket's status |
@@ -118,7 +118,7 @@ Each **queue** defined with `MatchmakingQueues` will have its own properties.
 
 First, the JSON `key` is the value that **tickets** will need to provide as their `queue_name` value. In the above [basic example](#basic-example), they are `solo`, `1v1` and `2v2`. This value is how **tickets** are sorted into **queues**.
 
-| Property | Definition |
+| <div style="width:190px">Property</div>| Definition |
 |-|-|
 | `QueueName` | Human readable **queue** name, used in logging |
 | `Teams` | Number of required teams in this **queue** |

--- a/features/parties/index.md
+++ b/features/parties/index.md
@@ -1,6 +1,5 @@
 # Parties
 
-
 The Catena `PartiesService` is responsible for the creation and updating of parties as well as handling various party related operations e.g. a player joining a party using an invite code.
 
 ## How does Catena define a party?
@@ -9,11 +8,11 @@ A `Party` is composed of a unique identifier `party_id`, the unique identifier o
 
 ```protobuf
 message Party {
-	string party_id = 1;
-	string leader_id = 2;
-	string invite_code = 3;
-	repeated Player players = 4;
-	map<string,groups.EntityMetadata> metadata = 5;
+    string party_id = 1;
+    string leader_id = 2;
+    string invite_code = 3;
+    repeated Player players = 4;
+    map<string,groups.EntityMetadata> metadata = 5;
 }
 ```
 
@@ -23,12 +22,12 @@ A `Player` is comprised of a unique identifier `player_id` (which is the same as
 
 ```protobuf
 message Player {
-	string player_id = 1;
-	string display_name = 2;
-	bool is_ready = 3;
-	bool is_leader = 4;
-	int32 team_number = 5;
-	map<string,groups.EntityMetadata> metadata = 6;
+    string player_id = 1;
+    string display_name = 2;
+    bool is_ready = 3;
+    bool is_leader = 4;
+    int32 team_number = 5;
+    map<string,groups.EntityMetadata> metadata = 6;
 }
 ```
 
@@ -40,9 +39,9 @@ Party creation is facilitated through the use of the `CreateParty` RPC.
 /* Creates a new party setting the player who requested its creation as its leader. */
 rpc CreateParty(CreatePartyRequest) returns (CreatePartyResponse) {
     option (google.api.http) = {
-		    post: "/api/v1/parties/create"
-			  body: "*"
-		};
+        post: "/api/v1/parties/create"
+        body: "*"
+    };
 };
 
 message CreatePartyRequest {
@@ -82,11 +81,11 @@ rpc UpdatePartyPlayer(UpdatePartyPlayerRequest) returns (UpdatePartyPlayerRespon
 
 message UpdatePartyPlayerRequest {
     Player payload = 1; // payload specifying what player info. to update
-	  google.protobuf.FieldMask payload_mask = 2;
+    google.protobuf.FieldMask payload_mask = 2;
 }
 
 message UpdatePartyPlayerResponse {
-	    Party party = 1; // the updated party (that the updated player is a member of)
+    Party party = 1; // the updated party (that the updated player is a member of)
 }
 ```
 
@@ -102,18 +101,18 @@ Currently, the `PartiesService` only supports joining a party by entering the in
 /* Allows a player to join a party by specifying its invite code. */
 rpc JoinPartyWithInviteCode(JoinPartyWithInviteCodeRequest) returns (JoinPartyWithInviteCodeResponse) {
     option (google.api.http) = {
-		    post: "/api/v1/parties/join"
-			  body: "*"
-		};
+        post: "/api/v1/parties/join"
+        body: "*"
+    };
 };
 
 message JoinPartyWithInviteCodeRequest {
     string invite_code = 1; // code used to join the party
-	  map<string,groups.EntityMetadata> joining_player_metadata = 2;
+    map<string,groups.EntityMetadata> joining_player_metadata = 2;
 }
 
 message JoinPartyWithInviteCodeResponse {
-	  Party party = 1; // the party that was joined
+    Party party = 1; // the party that was joined
 }
 ```
 
@@ -133,9 +132,9 @@ The `PartiesService` supports a player leaving their party via the `LeaveParty` 
 /* Allows a player to leave their party and assigns a new leader if the leader leaves. */
 rpc LeaveParty(LeavePartyRequest) returns (LeavePartyResponse) {
     option (google.api.http) = {
-		    put: "/api/v1/parties/leave"
-			  body: "*"
-		};
+        put: "/api/v1/parties/leave"
+        body: "*"
+    };
 };
 
 message LeavePartyRequest {
@@ -145,7 +144,7 @@ message LeavePartyRequest {
 message LeavePartyResponse {}
 ```
 
-Currently, a `LeaveParty` request must contain the `party_id` of the party a player is attempting to leave. However, this *****must***** be the party of which they are currently a member.
+Currently, a `LeaveParty` request must contain the `party_id` of the party a player is attempting to leave. However, this **\***must**\*** be the party of which they are currently a member.
 
 {% admonition type="info" %}
 If the player designated as the leader of the party leaves and they are the only player in the party, the party will be deleted. If there are other members in the party, another player will be designated as the new leader.
@@ -161,14 +160,14 @@ Yes! If a leader wants to relinquish their leadership of the party to another pa
 /* Allows the current leader of a party to set a new leader. */
 rpc SetPartyLeader(SetPartyLeaderRequest) returns (SetPartyLeaderResponse) {
     option (google.api.http) = {
-		    put: "/api/v1/parties/set-leader"
-			  body: "*"
-		};
+        put: "/api/v1/parties/set-leader"
+        body: "*"
+    };
 };
 
 message SetPartyLeaderRequest {
     string player_id = 1; // ID of player to set as party leader
-	  string party_id = 2; // ID of party to set leader of
+    string party_id = 2; // ID of party to set leader of
 }
 
 message SetPartyLeaderResponse {}
@@ -184,14 +183,14 @@ Yes, again! By providing the `party_id` of their party and the `player_id` of th
 /* Allows the leader of a party to kick another player from their party. */
 rpc KickFromParty(KickFromPartyRequest) returns (KickFromPartyResponse) {
     option (google.api.http) = {
-		    put: "/api/v1/parties/kick"
-			  body: "*"
-		};
+        put: "/api/v1/parties/kick"
+        body: "*"
+    };
 };
 
 message KickFromPartyRequest {
     string player_id = 1; // ID of player to kick from party
-	  string party_id = 2; // ID of party to kick player from
+    string party_id = 2; // ID of party to kick player from
 }
 
 message KickFromPartyResponse {}
@@ -207,8 +206,8 @@ A party’s information can be fetched by providing the ID of the party via `Get
 /* Fetches information for a party given a party ID. */
 rpc GetPartyInfoByPartyId(GetPartyInfoByPartyIdRequest) returns (GetPartyInfoResponse) {
     option (google.api.http) = {
-		    get: "/api/v1/parties/{party_id}"
-		};
+        get: "/api/v1/parties/{party_id}"
+    };
 };
 
 message GetPartyInfoByPartyIdRequest {
@@ -226,8 +225,8 @@ A party’s information can also be fetched via `GetPartyInfo` which determines 
 /* Fetches party information for the party that the requesting player is currently a member of. */
 rpc GetPartyInfo(GetPartyInfoRequest) returns (GetPartyInfoResponse) {
     option (google.api.http) = {
-		    get: "/api/v1/parties"
-		};
+        get: "/api/v1/parties"
+    };
 };
 
 message GetPartyInfoRequest {}
@@ -243,8 +242,8 @@ A party player’s information can be fetched via `GetPlayerInfoById` by providi
 /* Fetches information for a player in a party given an ID. */
 rpc GetPlayerInfoById(GetPlayerInfoByIdRequest) returns (GetPlayerInfoByIdResponse) {
     option (google.api.http) = {
-		    get: "/api/v1/parties/{player_id}"
-		};
+        get: "/api/v1/parties/{player_id}"
+    };
 };
 
 message GetPlayerInfoByIdRequest {
@@ -281,18 +280,18 @@ message PartyUpdateEvent {
     PartyUpdateType type = 1;
     string message = 2;
     string party_id = 3; // The party id this event is associated with
-	  map<string, PartyEventValue> event_payload = 4;
+    map<string, PartyEventValue> event_payload = 4;
 }
 
 message PartyEventValue {
     oneof value {
-		    bool bool_value = 1; 
-		    groups.EntityMetadata metadata_value = 2;
-		    string string_value = 3;
-		    Player player_value = 4; 
-		    int32 int_value = 5;
-		    groups.MetadataMap metadata_map_value = 6;
-	  }
+        bool bool_value = 1;
+        groups.EntityMetadata metadata_value = 2;
+        string string_value = 3;
+        Player player_value = 4;
+        int32 int_value = 5;
+        groups.MetadataMap metadata_map_value = 6;
+    }
 }
 ```
 

--- a/features/parties/index.md
+++ b/features/parties/index.md
@@ -19,7 +19,7 @@ message Party {
 
 ## How does Catena define a player?
 
-A `Player` is comprised of a unique identifier `player_id` that is the same as the player’s Catena `account_id`, a `display_name` that will be shown to other players in game, two boolean values `is_ready` and `is_leader` to track if the player has readied up or not and whether or not the player is the leader of the party respectively, a `team_number` that is assigned by a matchmaker, and a map of key-value metadata pairs.
+A `Player` is comprised of a unique identifier `player_id` (which is the same as the player’s Catena `account_id`), a `display_name` that will be shown to other players in game, two boolean values `is_ready` and `is_leader` to track if the player has readied up or not and whether or not the player is the leader of the party respectively, a `team_number` that is assigned by a matchmaker, and a map of key-value metadata pairs.
 
 ```protobuf
 message Player {
@@ -56,17 +56,17 @@ message CreatePartyResponse {
 
 The method handler for `CreateParty` will create a unique identifier for the party, generate and assign it a new six-digit alphanumeric invite code, and set the player who requested its creation as the party leader.
 
-The user who requested the party’s creation may also provide metadata specific to themselves as a player in this party in a `CreatePartyRequest`.
+With a `CreatePartyRequest`, the user requesting the party’s creation may also provide metadata specific to themselves as a player in this party.
 
 The newly created party will be returned in a `CreatePartyResponse`.
 
 ## Can parties be updated once created?
 
-Information specific to a party itself (`party_id` & `invite_code`) will not change after its creation.
+Information specific to a party itself (`party_id` and `invite_code`) will not change after its creation.
 
 What may be updated, however, are a party’s metadata, the list of players it maintains, and who the leader of the party is (`leader_id`).
 
-The players themselves may also update their own metadata as well as whether they are ready to begin matchmaking (`is_ready`).
+The players themselves may also update their own metadata, as well as whether they are ready to begin matchmaking (`is_ready`).
 
 All of these supported updates are facilitated through the use of the `UpdatePartyPlayer` RPC.
 
@@ -94,7 +94,9 @@ message UpdatePartyPlayerResponse {
 
 Currently, the `PartiesService` only supports joining a party by entering the invite code of the party a player is attempting to join. This is facilitated through the use of the `JoinPartyWithInviteCode` RPC.
 
-*Note: It is assumed that an existing member of the party will provide the player attempting to join with the party’s invite code.*
+{% admonition type="info" %}
+**Note:** It is assumed that an existing member of the party will provide the player attempting to join with the party’s invite code.
+{% /admonition %}
 
 ```protobuf
 /* Allows a player to join a party by specifying its invite code. */
@@ -117,9 +119,11 @@ message JoinPartyWithInviteCodeResponse {
 
 In a `JoinPartyWithInviteCodeRequest`, a player must specify the invite code of the party they are attempting to join, and may optionally provide metadata specific to themselves as a player in this party.
 
-If they were able to join the party successfully, they will be returned a `JoinPartyWithInviteCodeResponse` containing the `Party` object describing the party of which they are now a member.
+If they were able to join the party successfully, they will receive a `JoinPartyWithInviteCodeResponse` containing data describing the party of which they are now a member.
 
-**Note: There is currently no restriction on the number of players that may join a single party. That being said, parties attempting to enter matchmaking will have to be of a particular size depending on the game mode for which the matchmaker is attempting to form a match e.g. a max party size of three for a 3v3 game mode.**
+{% admonition type="info" %}
+There is currently no restriction on the number of players that may join a single party. That being said, parties attempting to enter matchmaking will have to be of a particular size depending on the matchmaker's configured game mode, e.g. a max party size of three for a 3v3 game mode.
+{% /admonition %}
 
 ## How can players leave a party?
 
@@ -143,7 +147,9 @@ message LeavePartyResponse {}
 
 Currently, a `LeaveParty` request must contain the `party_id` of the party a player is attempting to leave. However, this *****must***** be the party of which they are currently a member.
 
-*Note: If the player designated as the leader of the party leaves and they are the only player in the party, the party will be deleted. If there are other members in the party, another player will be designated as the new leader.*
+{% admonition type="info" %}
+If the player designated as the leader of the party leaves and they are the only player in the party, the party will be deleted. If there are other members in the party, another player will be designated as the new leader.
+{% /admonition %}
 
 ## Can a party leader transfer their leadership to another player in their party?
 
@@ -265,10 +271,10 @@ enum PartyUpdateType {
     PARTY_UPDATE_TYPE_PLAYER_LEFT = 2;
     PARTY_UPDATE_TYPE_PLAYER_KICKED = 3;
     PARTY_UPDATE_TYPE_PLAYER_READY_CHANGED = 4;
-	  PARTY_UPDATE_TYPE_PLAYER_LEADER_CHANGED = 5;
-	  PARTY_UPDATE_TYPE_METADATA_CREATED = 6;
-	  PARTY_UPDATE_TYPE_METADATA_UPDATED = 7;
-	  PARTY_UPDATE_TYPE_METADATA_DELETED = 8;
+    PARTY_UPDATE_TYPE_PLAYER_LEADER_CHANGED = 5;
+    PARTY_UPDATE_TYPE_METADATA_CREATED = 6;
+    PARTY_UPDATE_TYPE_METADATA_UPDATED = 7;
+    PARTY_UPDATE_TYPE_METADATA_DELETED = 8;
 }
 
 message PartyUpdateEvent {
@@ -292,21 +298,21 @@ message PartyEventValue {
 
 As shown in the `PartyUpdateType` enum, party update event notifications are broadcast in response to the following events:
 
-1. **A player joined the party**
-2. **A player left the party**
-3. **A player was kicked from the party**
-4. **A player’s “ready” status changed**
-5. **The party’s leader changed**
-6. **New metadata was added to the party**
-7. **Existing party metadata was updated**
-8. **Existing party metadata was deleted**
+- A player joined the party
+- A player left the party
+- A player was kicked from the party
+- A player’s “ready” status changed
+- The party’s leader changed
+- New metadata was added to the party
+- Existing party metadata was updated
+- Existing party metadata was deleted
 
 ## Metadata CRUD operations
 
-The Catena `PartiesService` supports various CRUD operations for:
+The Catena `PartiesService` supports operations for:
 
-1. Adding a metadata entry to a party(`CreateMetadataEntry`)
-2. Updating a metadata entry associated with a party (`UpdateMetadataEntry`)
-3. Deleting a metadata entry associated with a party (`DeleteMetadataEntry`)
-4. Getting **a single** metadata entry associated with a party (`GetMetadataEntry`)
-5. Getting **all** metadata entries associated with a party (`GetMetadataEntries`)
+- Adding a metadata entry to a party(`CreateMetadataEntry`)
+- Updating a metadata entry associated with a party (`UpdateMetadataEntry`)
+- Deleting a metadata entry associated with a party (`DeleteMetadataEntry`)
+- Getting **a single** metadata entry associated with a party (`GetMetadataEntry`)
+- Getting **all** metadata entries associated with a party (`GetMetadataEntries`)

--- a/guides/key-concepts.md
+++ b/guides/key-concepts.md
@@ -8,7 +8,11 @@ Catena is a source-available set of tools that is designed to help game develope
 
 ## Source Available
 
-Unlike other platforms, Catena gives you acces to its source code — which also means you are in charge of running it. Don’t worry, this isn’t as scary as it sounds! You have several options for how to do so, and you can [get up and running in just a few minutes](../installation/index.md).
+Unlike other platforms, Catena gives you access to its source code — which also means you are in charge of running it.
+
+{% admonition type="success" %}
+Don’t worry, this isn’t as scary as it sounds! You have several options for how to run Catena, and you can follow our guides to [get set up in just a few minutes](../installation/index.md).
+{% /admonition %}
 
 Since Catena is source available, you have the option to peel the curtain back and modify it to match the needs of your game. Catena handles the hard parts of implementing a game backend, and is designed in a similar manner to “engine code” you might find in Unreal Engine.
 

--- a/guides/key-concepts.md
+++ b/guides/key-concepts.md
@@ -1,24 +1,37 @@
 # Key Concepts
 
 {% admonition type="info" %}
-*For a deeper dive into key concepts, refer to [The Architecture of Catena](https://blog.catenatools.com/the-architecture-of-catena/) blog post.*
+For a deeper dive into key concepts, refer to [The Architecture of Catena](https://blog.catenatools.com/the-architecture-of-catena/) blog post.
 {% /admonition %}
 
-Catena is a source-available set of tools that is designed to help game developers build online games quickly and efficiently. With Catena, online features are interoperable, extensible, modular, easy to integrate with your game, and simple to run anywhere; even with limited backend experience.
+Catena is a source-available set of tools that is designed to help game developers build online games quickly and efficiently. With Catena, online features are interoperable, extensible, modular, easy to integrate with your game, and simple to run anywhere — even with limited backend experience.
 
 ## Source Available
 
-Unlike other platforms, you have access to Catena’s source code and must run it yourself. Don’t worry, this isn’t as scary as it sounds! You can get up and running in a few minutes with [Getting Started: How to Run Catena](../installation/index.md).
+Unlike other platforms, Catena gives you acces to its source code — which also means you are in charge of running it. Don’t worry, this isn’t as scary as it sounds! You have several options for how to do so, and you can [get up and running in just a few minutes](../installation/index.md).
 
-Because Catena is source available, you have the option to peel the curtain back and modify backend systems to match the needs of your game. Catena handles the hard parts of implementing a game backend, and is designed in a similar manner to “engine code” you might find in Unreal Engine.
+Since Catena is source available, you have the option to peel the curtain back and modify it to match the needs of your game. Catena handles the hard parts of implementing a game backend, and is designed in a similar manner to “engine code” you might find in Unreal Engine.
 
-Catena provides out-of-the-box support for configuration management, structured logging, authentication and session management, network transport between clients and servers, network transport between Catena services, database interfaces, module/plugin registration, and service discovery. 
+Catena provides out-of-the-box support for:
+- Configuration management
+- Structured logging
+- Authentication and session management
+- Network transport between clients and servers
+- Network transport between Catena services
+- Database interfaces
+- Module/plugin registration
+- Service discovery
 
 ## Interoperable, Extensible, Modular
 
 Catena is designed from the ground up to be interoperable, extensible, and modular. The “engine code” we provide is called “Catena Core”, which you will rarely need to touch or modify.
 
-On top of Catena Core, we provide modular and interoperable plugins that can get you started with an array of common online features such as identity and access management, commerce, matchmaking, game server management, social features, and more. These plugins can be used as-is, can easily be swapped with plugins to interface with other popular backend service platforms (i.e. AWS GameLift) for certain portions of your backend, or can be replaced with custom plugins written entirely by you in order to meet your game’s specific needs.
+On top of Catena Core, we provide modular and interoperable plugins that can get you started with an array of common online features such as identity and access management, commerce, matchmaking, game server management, social features, and more.
+
+Catena provides flexibility with regards to how these plugins can be used:
+- You can use them just as they are — they are designed to work together out-of-the-box.
+- They can easily be swapped out to interface with other popular backend service platforms (e.g. [AWS GameLift](https://aws.amazon.com/gamelift/)) for certain portions of your backend.
+- They can be replaced with custom plugins written entirely by you in order to meet your game’s specific needs.
 
 ## Easy to Integrate With Your Game
 

--- a/installation/aws-ec2.md
+++ b/installation/aws-ec2.md
@@ -10,7 +10,7 @@ markdown:
 Starting from scratch, deploying Catena to AWS on a single EC2 instance is estimated to take **30-45 minutes**.
 
 ## What Is Amazon EC2?
-[Amazon EC2](https://aws.amazon.com/ec2/) stands for Amazon Elastic Cloud Compute. It is Amazon's offering for creating and running virtual machines, called instances, in the cloud.
+[EC2](https://aws.amazon.com/ec2/) stands for Elastic Cloud Compute. It is Amazon's offering for creating and running virtual machines, called _instances_, in the cloud.
 
 ## Deployment Instructions
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
@@ -21,7 +21,7 @@ To deploy to AWS, you will also need to clone Catena's Infrastructure as Code re
 git clone git@github.com:CatenaTools/infrastructure.git
 ```
 
-### 2. Prep Work
+### 2. Preparations
 
 #### 2a. Create an AWS Account
 {% partial file="/_partials/aws/create-an-aws-account.md" /%}
@@ -35,18 +35,20 @@ git clone git@github.com:CatenaTools/infrastructure.git
 This guide requires using [Route53](https://aws.amazon.com/route53/) for your domain name.
 
 1. Register a new domain name or migrate an existing one
-    1. If you need to register a new domain name, refer to [this Route53 documenation about registering new domains](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-register.html#domain-register-procedure-section)
-    2. If you have an existing domain name, refer to [this Route53 documentation about making Route53 the DNS service for an existing domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html)
-2. If a "Hosted Zone" for your domain was not automatically created, refer to [this Route53 documentation about creating hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html)
+    - If you need to register a new domain name, refer to [this Route53 documenation about registering new domains](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-register.html#domain-register-procedure-section).
+    - If you have an existing domain name, refer to [this Route53 documentation about making Route53 the DNS service for an existing domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
+2. If a "Hosted Zone" for your domain was not automatically created, refer to [this Route53 documentation about creating hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html).
 
 #### 2d. Create an S3 Bucket
 [S3](https://aws.amazon.com/s3/), or Simple Storage Service, is where Catena's Infrastructure as Code will store information about the state of your deployment. This state can be accessed by other developers on your team to ensure that updates they make to your infrastructure are compatible with what is currently deployed.
 
-1. Navigate to the S3 portion of the AWS console. [Here is a link](https://us-east-1.console.aws.amazon.com/s3/home).
+1. Navigate to the [S3 portion](https://us-east-1.console.aws.amazon.com/s3/home) of the AWS console
 2. Click "Create bucket"
 3. Keep the default settings for all options
 4. Name your bucket. We'll call ours `catena-terraform-state`
-5. **Make note of the AWS Region on this page, you will need it later**
+{% admonition type="warning" %}
+**Make note of the AWS Region on this page. You will need it later.**
+{% /admonition %}
 
 #### 2e. Install Dependencies
 
@@ -168,11 +170,11 @@ git remote add dokku dokku@<your-url>:platform
 ```
 
 12. Use the appropriate command that was output from when you ran `terraform apply` to deploy Catena (this may take a while)
-    1. Options Include:
-        1. `powershell_deploy_command` if you are using Powershell
-        2. `windows_deploy_command` if you are using Windows Command Prompt
-        3. `unix_deploy_command` if you are using a Unix Based Command Prompt
-    2. When prompted if you'd like to continue connecting, select "yes"
+    - Options Include:
+        - `powershell_deploy_command` if you are using Powershell
+        - `windows_deploy_command` if you are using Windows Command Prompt
+        - `unix_deploy_command` if you are using a Unix Based Command Prompt
+    - When prompted if you'd like to continue connecting, select "yes"
 
 13. Check that Catena is running, by navigating to the URL specified in the `is_healthy` output from when you ran `terraform apply`
 
@@ -192,11 +194,10 @@ If you would like to see the details for each of these resources, you can look t
 Once these resources are provisioned, an init script is run on the EC2 instance that:
 1. Installs [Dokku](https://dokku.com/)
 2. Configures Dokku to recognize your domain name
-3. Installs [LetsEncrypt](https://letsencrypt.org/), to enable SSL
-    1. Generates a cert for your deployment
+3. Installs [LetsEncrypt](https://letsencrypt.org/), to enable SSL (generates a cert for your deployment)
 4. Creates a Catena app within Dokku
-    1. Configures a few necessary environment variables
-    2. Exposes this app to the outside world
+    - Configures a few necessary environment variables
+    - Exposes this app to the outside world
 5. Installs Redis and runs it
 6. Configures persistent database storage (SQLite)
 

--- a/installation/docker.md
+++ b/installation/docker.md
@@ -4,7 +4,7 @@
 Starting from scratch, running Catena on your machine using Docker is estimated to take **10-20 minutes**.
 
 ## What Is Docker?
-Docker is a tool used to create, deploy, and run applications using containers. Containers are similar to virtual machines, but don’t create an entire virtual operating system. When an application is built and packaged into a container alongside it’s dependencies it can be run quickly and reliably from one computing environment to another. For more information about Docker and containers, you can refer to [this piece of documentation from Docker](https://docs.docker.com/get-started/docker-overview/).
+Docker is a tool used to create, deploy, and run applications using containers. Containers are similar to virtual machines, but they don’t create an entire virtual operating system. Once an application is built and packaged into a container alongside its dependencies, it can be run quickly and reliably from different computing environments. For more information about Docker and containers, you can refer to [this piece of documentation from Docker](https://docs.docker.com/get-started/docker-overview/).
 
 ## Installation Instructions
 {% tabs %}
@@ -12,19 +12,19 @@ Docker is a tool used to create, deploy, and run applications using containers. 
         {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
 
         ### 2. Install WSL
-        There are two options for running with Docker, with Docker Desktop or by using Docker Engine directly. Both options will require you to install WSL to your machine.
+        There are two options for running with Docker: with Docker Desktop, or by using Docker Engine directly. Both options will require you to install WSL on your machine.
 
         {% partial file="/_partials/install-catena/install-wsl.md" /%}
 
         ### 3. Install Docker
         #### Using Docker Desktop
-        [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) is the easiest way to install Docker onto a Windows machine, though it requires a paid license for commercial use. If you prefer to register for a license, follow these instructions. Otherwise, skip to [Using Docker Engine Directly](./docker.md#using-docker-engine-directly).
+        [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/) is the easiest way to install Docker onto a Windows machine, though it requires a paid license for commercial use. If you prefer to register for a license, follow the instructions below. Otherwise, skip to [Using Docker Engine Directly](./docker.md#using-docker-engine-directly).
 
         1. [Download Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/)
         2. Begin installation
-            1. Ensure you select **Use WSL 2 instead of Hyper-V**
+            - Ensure you select **Use WSL 2 instead of Hyper-V**
         3. Once complete, [start Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/#start-docker-desktop)
-        4. From Powershell, check that Docker is working correctly
+        4. From Powershell, check that Docker is working correctly:
         {% code-snippet file="/_partials/install-catena/validate-docker-installation.md" title="validate-docker-installation" language="bash" /%}
         5. Proceed To [Run Catena](./docker.md#4.-run-catena)
 
@@ -58,18 +58,20 @@ Docker is a tool used to create, deploy, and run applications using containers. 
 
         ### 4. Run Catena
         1. Depending on how you installed Docker, use the corresponding command prompt to navigate to the root directory of the Catena Project:
-            1. **Docker Desktop:** Powershell
-            2. **Docker Engine:** WSL
-                1. *Note:* To navigate to a drive from WSL, such as your `C:\` drive, you will need to `cd /mnt/c/<YOUR_INSTALLATION_DIRECTORY>`
+            - **Docker Desktop:** Powershell
+            - **Docker Engine:** WSL
+                {% admonition type="info" %}
+                To navigate to a drive from WSL, such as your `C:\` drive, you will need to `cd /mnt/c/<YOUR_INSTALLATION_DIRECTORY>`
+                {% /admonition %}
         2. Use Docker Compose to run the project (this may take a while)
 
         ```bash
         docker compose up
         ```
 
-        3. Check that Catena is running either by sending a request from this page using the provided interactive API or by using cURL
+        3. Check that Catena is running either by sending a request from this page using the provided interactive API, or by using cURL.
 
-        #### Send Request from This Page
+        #### Send Request From This Page
         {% replay-openapi operationId="catena.catena_node_inspection.CatenaNodeInspection_NodeIsHealthy" descriptionFile="../apis/catena-tools-core.yaml" /%}
 
         #### Use cURL
@@ -158,16 +160,20 @@ Docker is a tool used to create, deploy, and run applications using containers. 
 {% /tabs %}
 
 ## What Does Docker Compose Run?
-By default running Docker Compose from Catena’s root directory will run a few different containers.
+By default, running Docker Compose from Catena’s root directory will run a few different containers:
 
 - `catena-tools-core`
-    - This is the Catena backend. The base `docker-compose.yaml` file will run with an assortment of Catena plugins enabled.
+    
+    This is the Catena backend. The base `docker-compose.yaml` file will run with an assortment of Catena plugins enabled.
 - `kafka`
-    - One configuration of Catena will use [Apache Kafka](https://kafka.apache.org/) to send messages between services. This is not a requirement to run Catena, but we run it alongside Catena in case you decide to use it.
+
+    One configuration of Catena will use [Apache Kafka](https://kafka.apache.org/) to send messages between services. This is not a requirement to run Catena, but we run it alongside Catena in case you decide to use it.
 - `init-kafka`
-    - Kafka requires “topics” to be created in order to send messages. The `init-kafka` container handles creating these topics before Catena is started.
+
+    Kafka requires “topics” to be created in order to send messages. The `init-kafka` container handles creating these topics before Catena is started.
 - `redis`
-    - Catena uses [Redis](https://redis.io/) for ephemeral storage, such as a session store. This is not a requirement to run Catena, but we run it alongside Catena in case you decide to use it.
+
+    Catena uses [Redis](https://redis.io/) for ephemeral storage, such as a session store. This is not a requirement to run Catena, but we run it alongside Catena in case you decide to use it.
 
 ## What Next?
 {% partial file="/_partials/install-catena/what-next.md" /%}

--- a/installation/heroku.md
+++ b/installation/heroku.md
@@ -15,7 +15,7 @@ Starting from scratch, deploying Catena to Heroku is estimated to take **10-20 m
 ## Deployment Instructions
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
 
-### 2. Prep Work
+### 2. Preparations
 
 #### 2a. Create a Heroku Account
 To create a Heroku account, you can [sign up here](https://signup.heroku.com/).
@@ -63,7 +63,7 @@ brew install git
 export PATH=/usr/local/bin:$PATH
 ```
 
-3. When you check the Git Version, it should now no longer say "Apple Git" in the version information
+3. When you check the Git Version, it should now no longer say "Apple Git" in the version information:
 
 ```bash
 git --version
@@ -86,7 +86,7 @@ heroku create catena-tools-core
 # https://catena-tools-core-d6fe81ff54bf.herokuapp.com/ | https://git.heroku.com/catena-tools-core.git
 ```
 
-3. This will automatically add a Git remote.
+3. This will automatically add a Git remote, which you can verify:
 
 ```bash
 git remote -v
@@ -103,7 +103,7 @@ git remote -v
 heroku buildpacks:set https://github.com/CatenaTools/dotnetcore-buildpack
 ```
 
-5. Configure PostgreSQL and Redis by first creating addons for each and then waiting for each to come online. This may take a few minutes.
+5. Configure PostgreSQL and Redis by first creating addons for each, and then waiting for them to come online. This may take a few minutes.
 
 ```bash
 heroku addons:create heroku-postgresql:essential-0 # "heroku addons:plans heroku-postgresql" to see options other than essential-0
@@ -178,7 +178,7 @@ remote:        Released v7
 remote:        https://catena-tools-core-328909998aac.herokuapp.com/ deployed to Heroku
 ```
 
-8. Check that Catena is running by navigating to [https://<your_deployment_url>/api/v1/node_inspection/is_healthy](https://<your_deployment_url>/api/v1/node_inspection/is_healthy)
+8. Check that Catena is running by navigating to `https://<your_deployment_url>/api/v1/node_inspection/is_healthy`.
 
 ## What Next?
 {% partial file="/_partials/install-catena/what-next.md" /%}

--- a/installation/index.md
+++ b/installation/index.md
@@ -1,6 +1,6 @@
 # Installation Options
 
-Catena is source available, that means you need to either run it on your machine or deploy it to a live environment that you control.
+Catena is **source available**, which means you need to either run it on your machine or deploy it to a live environment that you control.
 
 ## Running Catena Locally
 

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -3,6 +3,7 @@ extends:
 links:
   - href: https://fonts.googleapis.com/css2?family=VT323&display=swap
   - href: https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap
+  - href: https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap
 seo:
   title: Catena Tools API
   description: Catena Tools - Your game backend tool kit. Built by game developers, for game developers to simplify your game's backend workflow.

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -6,6 +6,7 @@ links:
   - href: https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap
   - href: https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap
   - href: https://fonts.googleapis.com/css2?family=Red+Hat+Text:ital,wght@0,300..700;1,300..700&display=swap
+  - href: https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400..700;1,400..700&display=swap
 seo:
   title: Catena Tools API
   description: Catena Tools - Your game backend tool kit. Built by game developers, for game developers to simplify your game's backend workflow.

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -4,6 +4,8 @@ links:
   - href: https://fonts.googleapis.com/css2?family=VT323&display=swap
   - href: https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap
   - href: https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap
+  - href: https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap
+  - href: https://fonts.googleapis.com/css2?family=Red+Hat+Text:ital,wght@0,300..700;1,300..700&display=swap
 seo:
   title: Catena Tools API
   description: Catena Tools - Your game backend tool kit. Built by game developers, for game developers to simplify your game's backend workflow.

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -8,11 +8,14 @@
         - group: "Running Catena Locally"
           items:
             - page: installation/docker.md
+              label: Running With Docker
             - page: installation/source.md
+              label: Running From Source
         - group: "Deploying Catena"
           items:
             - page: installation/heroku.md
             - page: installation/aws-ec2.md
+              label: Deploying to AWS
 - group: Unity
   page: engines/unity/index.md
   items:


### PR DESCRIPTION
Some suggested style tweaks and small copyedits throughout the documentation.

Many files have changes, but most are quite small (grammar/punctuation/formatting) and not content-altering. (Main goals were to prioritize ease of reading and to be more concise when possible.) The more significant changes to check out are:
- Styling (added some overrides for Redocly's CSS variable presets, with a link to the docs for further exploration)
- in `engines/unity/parties.md`, changed some of the heading levels and did a bit of content reorg
- in features/fleet-management/match-broker-allocators.md, changed heading labels to better fit the TOC