### PR TITLE
Adds a warning to our AWS-EC2 deploy guide about not using `root`, 

### DIFF
--- a/installation/aws-ec2.md
+++ b/installation/aws-ec2.md
@@ -27,6 +27,10 @@ git clone git@github.com:CatenaTools/infrastructure.git
 {% partial file="/_partials/aws/create-an-aws-account.md" /%}
 
 #### 2b. Create Credentials
+> **Do not use the AWS account root user!**
+>
+> Do not use the AWS account root user to deploy or operate Catena. The root user has unrestricted access to all AWS services and resources in the account, including billing and account-level settings. Catena does not require root user privileges for deployment or operation.
+
 {% partial file="/_partials/aws/create-credentials.md" variables={
     iam_username: "catena_deployment"
 } /%}


### PR DESCRIPTION
Does what it says on the tin!

Amazon has given us guidance that we should explicitly warn against using root IAM user, so now we do.