### PR TITLE
Adds an inventory of public-facing resources created as part of our AWS deployment guide.

### DIFF
--- a/installation/aws-public-resource-inventory.md
+++ b/installation/aws-public-resource-inventory.md
@@ -1,0 +1,24 @@
+## Public Resources Created by This Deployment
+
+This AWS deployment creates a single public Catena endpoint backed by one EC2
+instance.
+
+The following resources may be publicly reachable or may participate in public
+network access:
+
+| Resource | Purpose | Public exposure |
+|---|---|---|
+| EC2 instance | Runs Dokku and the Catena application | Receives inbound traffic allowed by the security group |
+| Elastic IP | Provides a stable public IPv4 address for the EC2 instance | Public IPv4 address |
+| Route53 records | Maps the configured domain name to the Catena deployment | Public DNS resolution |
+| Security group ingress rules | Controls inbound access to the EC2 instance | Any rule allowing traffic from `0.0.0.0/0` or `::/0` is publicly reachable |
+| Internet Gateway | Allows the VPC to communicate with the internet | Enables internet routing for public subnets |
+| Public subnet / route table | Places the EC2 instance on an internet-routable network path | Enables public access when combined with a public IP and permissive security group rules |
+| TLS certificate | Secures HTTPS access to the Catena endpoint | Public certificate for the configured hostname |
+
+Catena does not require unrestricted inbound access from the internet. Customers
+should expose only the ports required for their deployment and restrict
+administrative access to trusted networks.
+
+Redis and SQLite are installed on the EC2 instance for this deployment. They
+should not be directly exposed to the public internet.

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -14,8 +14,11 @@
         - group: "Deploying Catena"
           items:
             - page: installation/heroku.md
-            - page: installation/aws-ec2.md
-              label: Deploying to AWS
+            - group: "Deploying to AWS"
+              page: installation/aws-ec2.md
+              items:
+                - page: installation/aws-public-resource-inventory.md
+                  label: "Public Resources Created by This Deployment"
 - group: Unity
   page: engines/unity/index.md
   items:


### PR DESCRIPTION
Adds a clear and distinct page nested under our AWS Quick-Deploy instructions detailing what public resources are created as part of that guide.