### PR TITLE
Creates a deploy guide for using a scoped `CatenaDeployPolicy` for th…

### DIFF
--- a/_partials/aws/create-credentials.md
+++ b/_partials/aws/create-credentials.md
@@ -5,7 +5,8 @@
 5. Name your user. For the purposes of these instructions, we'll call ours "{% $iam_username %}".
     - Leave the "Provide user access to the AWS Management Console" option unchecked. This user will only require programmatic access to AWS.
 6. On the next step, select "Attach policies directly"
-    - In the policies list, check the `AdministratorAccess` policy.
+    - In the policies list, select the `CatenaDeploymentPolicy` you made in the previous step.
+
 7. Proceed to the "Review and create" step. Your user should look something like this:
 
 [ ![review and create user](/images/install-catena/review-and-create-user.png) ](/images/install-catena/review-and-create-user.png)

--- a/_partials/aws/examples-catena-deploy-policy.md
+++ b/_partials/aws/examples-catena-deploy-policy.md
@@ -1,0 +1,178 @@
+We'll be using a scoped IAM policy specifically for deployment in order to follow Least Privilege guidelines.
+The `catena_deploy` user will have this `CatenaDeploymentPolicy` policy attached.
+
+1. Log in to your AWS account that was created in the previous step.
+2. Navigate to Access Management -> Policies
+3. Create Policy
+4. Use the `JSON` Editor to paste in the custom policy below.
+5. Hit Next
+6. Give the policy a name like `CatenaDeploymentPolicy`
+7. Finish by creating the policy, then proceed to the next section.
+
+Replace the following placeholders before attaching the policy:
+
+| Placeholder | Example                                 | Description |
+|---|-----------------------------------------|---|
+| `<ACCOUNT_ID>` | `144518428993`  | AWS account ID where Catena will be deployed |
+| `<REGION>` | `us-east-1`  | AWS region used for the deployment |
+| `<TERRAFORM_STATE_BUCKET>` | `catena-terraform-state`  | S3 bucket used for Terraform state |
+| `<TERRAFORM_STATE_KEY_PREFIX>` | `ec2-gameserver/terraform.tfstate`  | Prefix/path used for this deployment’s Terraform state |
+| `<CATENA_EC2_ROLE_NAME>` | `catena-gameserver-ec2-role`  | IAM role name Terraform creates or uses for the Catena EC2 instance |
+| `<CATENA_EC2_INSTANCE_PROFILE_NAME>` | `catena-gameserver-ec2-instance-profile` | IAM instance profile name Terraform creates or uses for the Catena EC2 instance |
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "TerraformStateBucketList",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>"
+    },
+    {
+      "Sid": "TerraformStateObjectAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>/<TERRAFORM_STATE_KEY_PREFIX>/*"
+    },
+    {
+      "Sid": "ReadEC2State",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*",
+        "ec2:GetConsoleOutput"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaEC2VpcAndNetworkResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVpc",
+        "ec2:DeleteVpc",
+        "ec2:ModifyVpcAttribute",
+        "ec2:CreateSubnet",
+        "ec2:DeleteSubnet",
+        "ec2:ModifySubnetAttribute",
+        "ec2:CreateInternetGateway",
+        "ec2:DeleteInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:DetachInternetGateway",
+        "ec2:CreateRouteTable",
+        "ec2:DeleteRouteTable",
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute",
+        "ec2:AssociateRouteTable",
+        "ec2:DisassociateRouteTable",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ModifySecurityGroupRules",
+        "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+        "ec2:UpdateSecurityGroupRuleDescriptionsEgress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaEC2InstanceAndAddressResources",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:StartInstances",
+        "ec2:StopInstances",
+        "ec2:RebootInstances",
+        "ec2:AllocateAddress",
+        "ec2:AssociateAddress",
+        "ec2:DisassociateAddress",
+        "ec2:ReleaseAddress",
+        "ec2:ImportKeyPair",
+        "ec2:CreateKeyPair",
+        "ec2:DeleteKeyPair",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaRoute53Records",
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets",
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaEc2IamRoleAndInstanceProfile",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:TagRole",
+        "iam:UntagRole",
+        "iam:UpdateAssumeRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:ListRolePolicies",
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile",
+        "iam:GetInstanceProfile",
+        "iam:TagInstanceProfile",
+        "iam:UntagInstanceProfile",
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile"
+      ],
+      "Resource": [
+        "arn:aws:iam::<ACCOUNT_ID>:role/<CATENA_EC2_ROLE_NAME>",
+        "arn:aws:iam::<ACCOUNT_ID>:instance-profile/<CATENA_EC2_INSTANCE_PROFILE_NAME>"
+      ]
+    },
+    {
+      "Sid": "PassOnlyCatenaEc2Role",
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/<CATENA_EC2_ROLE_NAME>",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "ec2.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "UseEC2InstanceConnectForCatenaHost",
+      "Effect": "Allow",
+      "Action": [
+        "ec2-instance-connect:SendSSHPublicKey"
+      ],
+      "Resource": "arn:aws:ec2:<REGION>:<ACCOUNT_ID>:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:osuser": "ubuntu"
+        }
+      }
+    }
+  ]
+}
+```
+
+This policy is a starting point for the documented single-EC2 deployment. Your organization may need to adjust it based on the exact Terraform configuration, naming conventions, hosted zone setup, and security requirements.
+
+If Terraform reports an access denied error during `terraform plan` or `terraform apply`, review the missing action and update the policy intentionally rather than attaching `AdministratorAccess`.

--- a/_partials/aws/examples-catena-deploy-policy.md
+++ b/_partials/aws/examples-catena-deploy-policy.md
@@ -11,13 +11,14 @@ The `catena_deploy` user will have this `CatenaDeploymentPolicy` policy attached
 
 Replace the following placeholders before attaching the policy:
 
-| Placeholder | Example                                 | Description |
-|---|-----------------------------------------|---|
-| `<ACCOUNT_ID>` | `144518428993`  | AWS account ID where Catena will be deployed |
-| `<REGION>` | `us-east-1`  | AWS region used for the deployment |
-| `<TERRAFORM_STATE_BUCKET>` | `catena-terraform-state`  | S3 bucket used for Terraform state |
-| `<TERRAFORM_STATE_KEY_PREFIX>` | `ec2-gameserver/terraform.tfstate`  | Prefix/path used for this deployment’s Terraform state |
-| `<CATENA_EC2_ROLE_NAME>` | `catena-gameserver-ec2-role`  | IAM role name Terraform creates or uses for the Catena EC2 instance |
+| Placeholder                          | Example                                 | Description                                                                     |
+|--------------------------------------|-----------------------------------------|---------------------------------------------------------------------------------|
+| `<ACCOUNT_ID>`                       | `144518428993`                          | AWS account ID where Catena will be deployed                                    |
+| `<REGION>`                           | `us-east-1`                             | AWS region used for the deployment                                              |
+| `<TERRAFORM_STATE_BUCKET>`           | `catena-terraform-state`                | SS3 bucket used for Terraform remote state                                          |
+| `<TERRAFORM_STATE_PREFIX>`           | `catena-core/*`                         | S3 prefix Terraform may list while checking state and lock objects              |
+| `<TERRAFORM_STATE_KEY>`              | `catena-core/terraform.tfstate`         | Exact path used for this deployment’s Terraform state                           |
+| `<CATENA_EC2_ROLE_NAME>`             | `catena-gameserver-ec2-role`            | IAM role name Terraform creates or uses for the Catena EC2 instance             |
 | `<CATENA_EC2_INSTANCE_PROFILE_NAME>` | `catena-gameserver-ec2-instance-profile` | IAM instance profile name Terraform creates or uses for the Catena EC2 instance |
 
 ```json
@@ -30,7 +31,14 @@ Replace the following placeholders before attaching the policy:
       "Action": [
         "s3:ListBucket"
       ],
-      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>"
+      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "<TERRAFORM_STATE_PREFIX>"
+          ]
+        }
+      }
     },
     {
       "Sid": "TerraformStateObjectAccess",
@@ -40,7 +48,17 @@ Replace the following placeholders before attaching the policy:
         "s3:PutObject",
         "s3:DeleteObject"
       ],
-      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>/<TERRAFORM_STATE_KEY_PREFIX>/*"
+      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>/<TERRAFORM_STATE_KEY>"
+    },
+    {
+      "Sid": "TerraformStateLockAccess",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::<TERRAFORM_STATE_BUCKET>/<TERRAFORM_STATE_KEY>.tflock"
     },
     {
       "Sid": "ReadEC2State",

--- a/installation/aws-ec2.md
+++ b/installation/aws-ec2.md
@@ -26,7 +26,11 @@ git clone git@github.com:CatenaTools/infrastructure.git
 #### 2a. Create an AWS Account
 {% partial file="/_partials/aws/create-an-aws-account.md" /%}
 
-#### 2b. Create Credentials
+#### 2b. Create IAM Policy
+
+{% partial file="/_partials/aws/examples-catena-deploy-policy.md" /%}
+
+#### 2c. Create Credentials
 > **Do not use the AWS account root user!**
 >
 > Do not use the AWS account root user to deploy or operate Catena. The root user has unrestricted access to all AWS services and resources in the account, including billing and account-level settings. Catena does not require root user privileges for deployment or operation.
@@ -35,7 +39,7 @@ git clone git@github.com:CatenaTools/infrastructure.git
     iam_username: "catena_deployment"
 } /%}
 
-#### 2c. Configure Your Domain
+#### 2d. Configure Your Domain
 This guide requires using [Route53](https://aws.amazon.com/route53/) for your domain name.
 
 1. Register a new domain name or migrate an existing one
@@ -43,7 +47,7 @@ This guide requires using [Route53](https://aws.amazon.com/route53/) for your do
     - If you have an existing domain name, refer to [this Route53 documentation about making Route53 the DNS service for an existing domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html).
 2. If a "Hosted Zone" for your domain was not automatically created, refer to [this Route53 documentation about creating hosted zones](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html).
 
-#### 2d. Create an S3 Bucket
+#### 2e. Create an S3 Bucket
 [S3](https://aws.amazon.com/s3/), or Simple Storage Service, is where Catena's Infrastructure as Code will store information about the state of your deployment. This state can be accessed by other developers on your team to ensure that updates they make to your infrastructure are compatible with what is currently deployed.
 
 1. Navigate to the [S3 portion](https://us-east-1.console.aws.amazon.com/s3/home) of the AWS console
@@ -54,7 +58,7 @@ This guide requires using [Route53](https://aws.amazon.com/route53/) for your do
 **Make note of the AWS Region on this page. You will need it later.**
 {% /admonition %}
 
-#### 2e. Install Dependencies
+#### 2f. Install Dependencies
 
 ##### AWS CLI
 {% partial file="/_partials/aws/install-aws-cli.md" variables={


### PR DESCRIPTION
Replaces `AdministratorAccess` advice in our AWS Guide for `catena_deploy`'s IAM Policy.

Creates a new policy specifically for the deploy account, with all necessary permissions.  It could probably be tightened further, but its significantly more scoped than open admin access.