### PR TITLE
Hides Heroku deploy guide for now, as it has plaintext passwords

### DIFF
--- a/installation/index.md
+++ b/installation/index.md
@@ -20,11 +20,7 @@ Run Catena With Docker on Your Machine
 
 Alternatively, you can deploy Catena to live environment such as Heroku or AWS.
 
-{% cards columns=2 %}
-{% card title="Heroku" to="./heroku.md" %}
-Use this method if you prefer the quickest and easiest deployment.
-{% /card %}
-
+{% cards columns=1 %}
 {% card title="AWS (Single Node)" to="./aws-ec2.md" %}
 Use this method if you prefer to run your infrastructure on AWS.
 {% /card %}

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -14,7 +14,6 @@
               label: Running From Source
         - group: "Deploying Catena"
           items:
-            - page: installation/heroku.md
             - group: "Deploying to AWS"
               page: installation/aws-ec2.md
               items:


### PR DESCRIPTION
As part of the effort to get our deploy guides up to security guidelines, hiding the Heroku deploy guide until it can be updated to handle its plaintext db secrets.