### PR TITLE
Add details on why keys are being generated and their locations

### DIFF
--- a/_partials/aws/create-credentials.md
+++ b/_partials/aws/create-credentials.md
@@ -14,7 +14,8 @@
 8. Create the user
 9. Navigate to the user's details
 10. Select "Security credentials"
-11. Under the "Access keys" section, select "Create access key"
+11. Under the "Access keys" section, select "Create access key" to create secret keys for the "{% $iam_username %}" IAM user
+    - These keys will later be passed to the AWS CLI (and by extension Terraform) so that the IAM user can authenticate as "{% $iam_username %}" when provisioning resources in AWS.
 12. Select "Third-party service"
     {% admonition type="info" %}
     Note: AWS will recommend an alternative option. For ease, we will ignore this for the time being. Select "I understand the above recommendation and want to proceed to create an access key".

--- a/installation/aws-ec2.md
+++ b/installation/aws-ec2.md
@@ -67,6 +67,10 @@ This guide requires using [Route53](https://aws.amazon.com/route53/) for your do
     profile_name: "catena_deploy"
 } /%}
 
+    {% admonition type="info" %}
+    Note: This is going to store the credentials on your local machine in `~/.aws/credentials` on Linux or `%USERPROFILE%\.aws\credentials` on Windows.
+    {% /admonition %}
+
 ##### Terraform
 {% partial file="/_partials/aws/terraform.md" /%}
 
@@ -95,8 +99,10 @@ In order to deploy Catena, you will need to generate an SSH key.
 {% /tabs %}
 
 This will generate two files, each of which will be used by Terraform when deploying Catena:
-* `catena_deploy_key`
-* `catena_deploy_key.pub`
+* `catena_deploy_key` - Private Key that stays local to your machine, will be referenced later when deploying to the instance (see step 3 below).
+* `catena_deploy_key.pub` - Public Key that Terraform uploads to AWS as an EC2 key pair during `terraform apply`, provisioning SSH access to the instance it creates.
+
+These files will be created on your local machine in `%USERPROFILE%\.ssh\` on Windows or `~/.ssh/` on Linux
 
 ### 3. Deploy Catena
 Now that you have everything prepped, it's time to actually deploy Catena.


### PR DESCRIPTION
DSEC-006: Deployment guide should describe the purpose and location of each key the user is instructed to create.

This change adds details around generating AWS secret keys for catena deployment. Detailing what the keys are for and where they get stored on use.

Also adding details around SSH keys and how they are used in the deployment process for deploying and providing SSH access.