### PR TITLE
Added descriptions for IAM roles and Policies used in deployment

### DIFF
--- a/_partials/aws/examples-catena-deploy-policy.md
+++ b/_partials/aws/examples-catena-deploy-policy.md
@@ -18,8 +18,8 @@ Replace the following placeholders before attaching the policy:
 | `<TERRAFORM_STATE_BUCKET>`           | `catena-terraform-state`                | SS3 bucket used for Terraform remote state                                          |
 | `<TERRAFORM_STATE_PREFIX>`           | `catena-core/*`                         | S3 prefix Terraform may list while checking state and lock objects              |
 | `<TERRAFORM_STATE_KEY>`              | `catena-core/terraform.tfstate`         | Exact path used for this deployment’s Terraform state                           |
-| `<CATENA_EC2_ROLE_NAME>`             | `catena-gameserver-ec2-role`            | IAM role name Terraform creates or uses for the Catena EC2 instance             |
-| `<CATENA_EC2_INSTANCE_PROFILE_NAME>` | `catena-gameserver-ec2-instance-profile` | IAM instance profile name Terraform creates or uses for the Catena EC2 instance |
+| `<CATENA_EC2_ROLE_NAME>`             | `catena-ec2-role`            | IAM role name Terraform creates or uses for the Catena EC2 instance. following the pattern `<workspace_prepend>catena-ec2-role`. For a standard deployment using Terraform's default workspace, this value will be `catena-ec2-role.`    |
+| `<CATENA_EC2_INSTANCE_PROFILE_NAME>` | `catena-ec2-instance-profile` | IAM instance profile name Terraform creates or uses for the Catena EC2 instance |
 
 ```json
 {
@@ -130,6 +130,7 @@ Replace the following placeholders before attaching the policy:
         "route53:ListHostedZones",
         "route53:ListHostedZonesByName",
         "route53:ListResourceRecordSets",
+        "route53:ListTagsForResource",   
         "route53:ChangeResourceRecordSets"
       ],
       "Resource": "*"
@@ -148,6 +149,8 @@ Replace the following placeholders before attaching the policy:
         "iam:GetRolePolicy",
         "iam:DeleteRolePolicy",
         "iam:ListRolePolicies",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListInstanceProfilesForRole",
         "iam:CreateInstanceProfile",
         "iam:DeleteInstanceProfile",
         "iam:GetInstanceProfile",
@@ -161,6 +164,24 @@ Replace the following placeholders before attaching the policy:
         "arn:aws:iam::<ACCOUNT_ID>:instance-profile/<CATENA_EC2_INSTANCE_PROFILE_NAME>"
       ]
     },
+    {
+			"Sid": "ManageCatenaPolicies",
+			"Effect": "Allow",
+			"Action": [
+				"iam:CreatePolicy",
+				"iam:DeletePolicy",
+				"iam:GetPolicy",
+				"iam:GetPolicyVersion",
+				"iam:ListPolicyVersions",
+				"iam:CreatePolicyVersion",
+				"iam:DeletePolicyVersion",
+				"iam:TagPolicy",
+				"iam:ListEntitiesForPolicy"
+			],
+			"Resource": [
+				"arn:aws:iam::<ACCOUNT_ID>:policy/*catena-backup-policy"
+			]
+		},
     {
       "Sid": "PassOnlyCatenaEc2Role",
       "Effect": "Allow",
@@ -186,11 +207,81 @@ Replace the following placeholders before attaching the policy:
           "ec2:osuser": "ubuntu"
         }
       }
-    }
+    },
+    {
+		  "Sid": "AttachOnlyCatenaManagedPolicies",
+		  "Effect": "Allow",
+		  "Action": [
+        "iam:AttachRolePolicy", 
+        "iam:DetachRolePolicy"
+        ],
+		  "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/*catena-ec2-role*",
+		  "Condition": {
+		    "ArnLike": {
+		      "iam:PolicyARN": [
+				"arn:aws:iam::<ACCOUNT_ID>:policy/*catena*",
+				"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+				]
+		    }
+		  }
+		},
+		{
+		  "Sid": "ManageCatenaBackupBucket",
+		  "Effect": "Allow",
+		  "Action": [
+			"s3:CreateBucket",
+			"s3:DeleteBucket",
+			"s3:GetBucketLocation",
+			"s3:GetBucketVersioning",
+			"s3:PutBucketVersioning",
+			"s3:GetBucketPolicy",
+			"s3:PutBucketPolicy",
+			"s3:DeleteBucketPolicy",
+			"s3:GetBucketTagging",
+			"s3:PutBucketTagging",
+			"s3:GetBucketPublicAccessBlock",
+			"s3:PutBucketPublicAccessBlock",
+			"s3:GetLifecycleConfiguration",
+			"s3:PutLifecycleConfiguration",
+			"s3:GetEncryptionConfiguration",
+			"s3:PutEncryptionConfiguration"
+		  ],
+		  "Resource": "arn:aws:s3:::catena-backup"
+		},
+		{
+		  "Sid": "ManageCatenaBackupBucketObjects",
+		  "Effect": "Allow",
+		  "Action": [
+			"s3:GetObject",
+			"s3:PutObject",
+			"s3:DeleteObject",
+			"s3:ListBucket"
+		  ],
+		  "Resource": [
+			"arn:aws:s3:::catena-backup",
+			"arn:aws:s3:::catena-backup/*"
+		  ]
+		}
   ]
 }
 ```
 
 This policy is a starting point for the documented single-EC2 deployment. Your organization may need to adjust it based on the exact Terraform configuration, naming conventions, hosted zone setup, and security requirements.
+
+Here is a table breaking down all the Sids used in the starting point deployment policy above:
+| SID                          | Description                                                                     |
+|--------------------------------------|---------------------------------------------------------------------------------|
+| `TerraformStateBucketList`/ `TerraformStateObjectAccess`/ `TerraformStateLockAccess `   | Lets Terraform read/write its own state file and lock in S3
+| `ManageCatenaEC2VpcAndNetworkResources ` | Create the VPC, subnets, gateway, routing, security group
+| `ManageCatenaEC2InstanceAndAddressResources `  | Create/manage the EC2 instance and its Elastic IP  
+| `ManageCatenaRoute53Records` | Point your domain at the new instance             |
+| `ManageCatenaEc2IamRoleAndInstanceProfile `   | Create the second IAM role below 
+| `ManageCatenaPolicies `   | 		Create, read, version, tag, and delete the runtime IAM policy for backup  | 
+| `PassOnlyCatenaEc2Role `             | Lets Terraform hand that role to EC2 — scoped so it can't pass any other role
+| `UseEC2InstanceConnectForCatenaHost ` | Lets you SSH in via EC2 Instance Connect later 
+| `AttachOnlyCatenaManagedPolicies` | Lets terraform attach/detach policies to the EC2 instance role, but restricted to only Catena-managed policies and the specific AWS managed policy
+| `ManageCatenaBackupBucket` | Create and configure the S3 bucket used for database backups (Versioning, lifecycle policy, encryption, public access)
+| `ManageCatenaBackupBucketObjects` | Read, Write, delete, and list objects within the backup bucket
+
 
 If Terraform reports an access denied error during `terraform plan` or `terraform apply`, review the missing action and update the policy intentionally rather than attaching `AdministratorAccess`.

--- a/_partials/matchmaking/fresh-new.md
+++ b/_partials/matchmaking/fresh-new.md
@@ -1,0 +1,15 @@
+Now that we covered some background, its time to provison some resources. If you already went through the AWS EC2 deployment steps, follow these to deploy alongside your running Catena instance:
+
+{% cards columns=1 %}
+    {% card title="Existing AWS deployment" to="../../features/matchmaking/aws-flex-match-existing-deployment.md" %}
+        Deploy flex match alongside Catena already running in an AWS EC2 instance
+    {% /card %}
+{% /cards %}
+
+If you haven't deployed anything to AWS yet, follow our fresh deploy steps:
+
+{% cards columns=1 %}
+    {% card title="First AWS Deployment" to="../../features/matchmaking/aws-flex-match-new-deployment.md" %}
+        Deploy flex match to a fresh AWS instance with no current running resources
+    {% /card %}
+{% /cards %}

--- a/features/matchmaking/aws-flex-match-existing-deployment.md
+++ b/features/matchmaking/aws-flex-match-existing-deployment.md
@@ -1,0 +1,303 @@
+---
+markdown:
+  toc:
+    depth: 4
+---
+
+# Catena - AWS FlexMatch - Exisitng deployment
+
+This document assumes you've already deployed Catena tools to AWS using [AWS EC2 deplyoment docs](../../installation/aws-ec2.md), and have a working `catena_deployment` user and EC2 role.
+
+If you have not deployed to AWS yet and this is your first time, please refer too [Flex Match New Deployment steps](./aws-flex-match-new-deployment.md)
+
+AWS FlexMatch is responsible for grouping players together to form games or matches. Catena's integration into FlexMatch currently supports FlexMatch's "standalone" configuration, meaning that it only supports making matches and does not support provisioning game servers via AWS GameLift.
+
+### 1. Preparations
+
+#### 1a. Create an AWS Account
+{% partial file="/_partials/aws/create-an-aws-account.md" /%}
+
+#### 1b. Extend deployment IAM User and Policy
+
+You don't need a new IAM user. We can use the identities we created earlier for deployment, and our EC2 instance role.
+
+1. Log into AWS and navigate to `IAM` -> `IAM Policies`
+
+2. Select your `CatenaDeploymentPolicy` we created to deploy Catena. (`CatenaDeploymentPolicy`, attached to `catena_deployment` IAM user). open the Json editor and add in these permissions: 
+
+```json
+{
+  "Sid": "AttachOnlyCatenaManagedPolicies",
+  "Effect": "Allow",
+  "Action": [
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy"
+  ],
+  "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/*catena-ec2-role*",
+  "Condition": {
+      "ArnLike": {
+          "iam:PolicyARN": [
+              "arn:aws:iam::<ACCOUNT_ID>:policy/*catena*",
+              "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+          ]
+      }
+  }
+},
+{
+  "Sid": "CloudControlApiForGameLiftResources",
+  "Effect": "Allow",
+  "Action": [
+    "cloudformation:GetResource",
+    "cloudformation:CreateResource",
+    "cloudformation:UpdateResource",
+    "cloudformation:DeleteResource",
+    "cloudformation:ListResources",
+    "cloudformation:GetResourceRequestStatus",
+    "cloudformation:ListResourceRequests"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "ManageCatenaSnsNotificationTopic",
+  "Effect": "Allow",
+  "Action": [
+    "sns:CreateTopic", 
+    "sns:DeleteTopic", 
+    "sns:GetTopicAttributes",
+    "sns:SetTopicAttributes", 
+    "sns:TagResource", 
+    "sns:ListTagsForResource",
+    "sns:Subscribe", 
+    "sns:Unsubscribe", 
+    "sns:GetSubscriptionAttributes"
+  ],
+  "Resource": "arn:aws:sns:*:*:*"
+},
+{
+  "Sid": "ManageCatenaSqsNotificationQueue",
+  "Effect": "Allow",
+  "Action": [
+    "sqs:CreateQueue", 
+    "sqs:DeleteQueue", 
+    "sqs:GetQueueAttributes",
+    "sqs:SetQueueAttributes", 
+    "sqs:TagQueue", 
+    "sqs:ListQueueTags",
+    "sqs:GetQueueUrl", 
+    "sqs:AddPermission"
+  ],
+  "Resource": "arn:aws:sqs:*:*:*"
+},
+{
+  "Sid": "ManageCatenaGameLiftMatchmakingRuleSets",
+  "Effect": "Allow",
+  "Action": [
+    "gamelift:CreateMatchmakingRuleSet", 
+    "gamelift:DeleteMatchmakingRuleSet",
+    "gamelift:DescribeMatchmakingRuleSets", 
+    "gamelift:TagResource", 
+    "gamelift:ListTagsForResource"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "ManageCatenaGameLiftMatchmakingConfigurations",
+  "Effect": "Allow",
+  "Action": [
+    "gamelift:CreateMatchmakingConfiguration", 
+    "gamelift:UpdateMatchmakingConfiguration",
+    "gamelift:DeleteMatchmakingConfiguration", 
+    "gamelift:DescribeMatchmakingConfigurations"
+  ],
+  "Resource": "*"
+},
+{
+  "Sid": "ManageCatenaFlexMatchRuntimePolicy",
+  "Effect": "Allow",
+  "Action": [
+    "iam:CreatePolicy", 
+    "iam:DeletePolicy", 
+    "iam:GetPolicy",
+    "iam:GetPolicyVersion", 
+    "iam:ListPolicyVersions",
+    "iam:CreatePolicyVersion", 
+    "iam:DeletePolicyVersion",
+    "iam:TagPolicy", 
+    "iam:ListEntitiesForPolicy"
+  ],
+  "Resource": "arn:aws:iam::414845328991:policy/*catena-flexmatch-runtime-policy"
+}
+```
+> **Note:** GameLift matchmaking actions don't support resource-level ARN scoping — AWS requires `"Resource": "*"` for these specific actions.
+
+There is one existing policy you will have to edit to add the ability to edit flexmatch runtime policies. Yuu should have this permission added from the `catena-tools-core` deployment to manage your backup permissions. 
+
+We should add the 2nd resource arn to allow managing the runtime policy for FlexMatch as well:
+
+```json
+{
+  "Sid": "ManageCatenaPolicies",
+  "Effect": "Allow",
+  "Action": [
+    "iam:CreatePolicy",
+    "iam:DeletePolicy",
+    "iam:GetPolicy",
+    "iam:GetPolicyVersion",
+    "iam:ListPolicyVersions",
+    "iam:CreatePolicyVersion",
+    "iam:DeletePolicyVersion",
+    "iam:TagPolicy",
+    "iam:ListEntitiesForPolicy"
+  ],
+  "Resource": [
+    "arn:aws:iam::<ACCOUNT_ID>:policy/*catena-backup-policy",
+    "arn:aws:iam::<ACCOUNT_ID>:policy/*catena-flexmatch-runtime-policy" # Add this Resource ARN here
+  ]
+}
+```
+
+Once done, scroll down and click `Next`. Review your changes and once confirmed you can scroll down and `Save Changes`
+
+This will enable `catena_deployment` to provision FlexMatch's resources.
+
+Here is the breakdown of the deployment SIDs:
+| SID                          | Purpose                                 | 
+|--------------------------------------|-----------------------------------------|
+| `AttachOnlyCatenaManagedPolicies` | 		(existing deployments only)	Attach and detach policies to the Catena EC2 instance role. Scoped only to catena policies and the one required AmazonSSMMangedInstanceCore  | 
+| `CloudControlApiForGameLiftResources` | 		Create, read, update, delete, and poll the status of resources managed through AWS Cloud Control API. Terraforms awscc provider routes all operations through Cloud Control.  | 
+| `ManageCatenaSnsNotificationTopic` | 	Create and configure the SNS topic FlexMatch uses to publish matchmaking events | 
+| `ManageCatenaSqsNotificationQueue` | 	Create and configure the SQS queue subscribed to that topic, which Catena polls for matchmaking updates |                                            |
+| `ManageCatenaGameLiftMatchmakingRuleSets` | 	Create/manage the GameLift rule sets defining team structure and match sizing|
+| `ManageCatenaGameLiftMatchmakingConfigurations` | 	Create/manage the GameLift matchmaking configurations that expose matchmaking to players  | 
+| `ManageCatenaPolicies` | 		Create, read, version, tag, and delete the FlexMatch runtime IAM policy  | 
+
+Now that we have our deployment policy setup, we can apply our changes. Navigate to `aws/catena-core/` in the infrastructure repo and run:
+
+```bash
+terraform plan -var-file="vars.tfvars"
+terraform apply -var-file="vars.tfvars"
+```
+
+Your deployment policies should be configured and you should now have flexmatch deployed
+
+### 2. Configure FlexMatch
+Now that you have everything prepped, it's time to configure FlexMatch in your AWS account. We will be using Terraform to configure the various components necessary for FlexMatch to operate. These include:
+
+**Matchmaking Ruleset(s)**
+
+[FlexMatch Rulesets](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-rulesets.html) define your game's team structure, size, and how to group players together for the best possible match.
+
+**Matchmaking Configuration(s)**
+
+[FlexMatch Configurations](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-create-configuration.html) expose matchmaking functionality to the outside world. These are how Catena makes matchmaking requests to AWS.
+
+**Simple Notification Service (SNS) Topic**
+
+[AWS SNS](https://aws.amazon.com/sns/) gives FlexMatch a place to post matchmaking events as they occur (i.e. match created).
+
+**Simple Queue Service (SQS) Queue**
+
+[AWS SQS](https://aws.amazon.com/sqs/) gives applications a way to subscribe to events that are sent to SNS topics. This is how Catena listens for matchmaking events for specific matchmaking tickets.
+
+#### 2a. Provision Resources
+1. Navigate to the Catena Infrastructure repository you cloned earlier.
+2. Navigate to the `aws/flex-match/` directory
+3. Initialize Terraform
+
+```bash
+terraform init
+```
+
+4. If you would like to customize the matchmaking queues that are available, edit the `matchmaking_queues` variable in `variables.tf`. For every queue name, you will need to define a corresponding ruleset in the `rule_sets/` directory. For more information on rule sets, refer to the [match rulesets](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-rulesets.html) documentation from Amazon.
+
+5. (Optional) Run a Terraform plan. This will preview all of the AWS resources that are about to be provisioned.
+
+```bash
+terraform plan --var="catena_ec2_role_name=<your-ec2-role-name>"
+```
+Passing `catena_ec2_role_name` tells Terraform to attach the FlexMatch runtime policy to your existing EC2 instance role. Alongside that, it creates the SNS topic, SQS queue, GameLift rule sets, and matchmaking configurations.
+
+Your role name follows the pattern `<workspace>-catena-ec2-role` — for the default workspace, it's just `catena-ec2-role`.
+
+6. Run a Terraform apply. This will preview all of the AWS resource that are about to be provisioned, and prompt you if you'd like to proceed.
+
+```bash
+terraform apply --var="catena_ec2_role_name=<your-ec2-role-name>"
+```
+
+You should see a long list of output, with something resembling the following code block at the end.
+
+_Note: This is just example output._
+
+```bash
+Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+sqs_queue_url = "https://sqs.us-east-1.amazonaws.com/000000000000/matchmaking-events"
+flexmatch_runtime_user_name = "my_workspace_catena_flexmatch_runtime_policy"
+```
+
+7. Keep note of the `sqs_queue_url` that it outputs, as it will be used to configure your running instance of Catena in the next step.
+
+Running terraform Apply will have created a new IAM Policy titled `catena_flexmatch_runtime_policy`. Here is a breakdown of it's SIDS:
+
+| SID                          | Purpose                                 | 
+|--------------------------------------|-----------------------------------------|
+| `CatenaRuntimeGameLiftMatchmaking` | Lets running Catena application start, stop, and check matchmaking status via GameLift | 
+| `CatenaRuntimeSqsNotifications` | Lets the running application read and acknowledge matchmaking event messages from the FlexMatch notification queue | 
+
+#### 2b. Configure Catena
+Once you have your resources provisioned, you can configure Catena. Catena is configured using appsettings files in `catena-tools-core`. You will need the following items for Catena to work with FlexMatch:
+
+```json
+{
+    "Catena": {
+        ...
+        "Matchmaker": {
+            "FlexMatch": {
+                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
+                "GameLiftConfig": {
+                    "Profile": "<your_aws_profile_from_aws_cli>",
+                    "Region": "<your_aws_region_from_aws_cli>"
+                }
+            }
+        }
+        ...
+    },
+    "PreferredImplementations": {
+        ...
+        "ICatenaMatchmaker": "!AwsFlexMatch"
+        ...
+    }
+}
+```
+
+Alternatively, you can expose your access key/secret key directly, though you _should not_ check these values into source control.
+
+```json
+{
+    "Catena": {
+        ...
+        "Matchmaker": {
+            "FlexMatch": {
+                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
+                "GameLiftConfig": {
+                    "AccessKey": "<your_aws_access_key>",
+                    "SecretKey": "<your_aws_secret_key>",
+                    "Region": "<your_aws_region_from_aws_cli>"
+                }
+            }
+        }
+        ...
+    },
+    "PreferredImplementations": {
+        ...
+        "ICatenaMatchmaker": "!AwsFlexMatch"
+        ...
+    }
+}
+```
+
+## What Next?
+{% partial file="/_partials/matchmaking/what-next.md" /%}

--- a/features/matchmaking/aws-flex-match-new-deployment.md
+++ b/features/matchmaking/aws-flex-match-new-deployment.md
@@ -1,0 +1,333 @@
+---
+markdown:
+  toc:
+    depth: 4
+---
+
+# Catena - AWS FlexMatch - New Deployment
+
+This document assumes you have not ran through [AWS EC2 deplyoment steps](../../installation/aws-ec2.md). You should have Catena deployed outside of AWS. We will step through as though there is currently no resources deployed in AWS.
+
+If do have Catena deployed to AWS please refer too [Exisitng Deployment steps](./aws-flex-match-existing-deployment.md)
+
+AWS FlexMatch is responsible for grouping players together to form games or matches. Catena's integration into FlexMatch currently supports FlexMatch's "standalone" configuration, meaning that it only supports making matches and does not support provisioning game servers via AWS GameLift.
+
+If you would like to learn more about how Catena handles dedicated game servers, refer to the [Match Broker](../game-servers/index.md) documentation.
+
+## Engine Integration
+
+{% partial file="/_partials/matchmaking/engine-integration.md" variables={implementation: "AWS FlexMatch" } /%}
+
+## What is AWS FlexMatch?
+
+[AWS FlexMatch](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-intro.html), also known as "Amazon GameLift Servers FlexMatch" is Amazon's offering for matchmaking players.
+
+## Getting Started
+
+{% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
+
+To configure FlexMatch, you will also need to clone Catena's Infrastructure as Code repository.
+
+```bash
+git clone git@github.com:CatenaTools/infrastructure.git
+```
+
+### 2. Preparations
+
+#### 2a. Create an AWS Account
+Since this is your first deployment, you will need to setup an AWS account
+
+{% partial file="/_partials/aws/create-an-aws-account.md" /%}
+
+#### 2b. Setup Deployment IAM User and Policy
+
+We need to setup user roles and permissions for using FlexMatch.
+
+Right now we will setup the deployment user that allows us to provision our resources.
+
+1. Log into the account you created in the previous step
+
+2. Navigate to `IAM` -> `IAM Policies` and select `Create Policy`
+
+3. Switch to edit with Json editor and paste the following permissions. This is the deployment policy which will allow us to provision FlexMatches resources via terraform
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudControlApiForGameLiftResources",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:GetResource",
+        "cloudformation:CreateResource",
+        "cloudformation:UpdateResource",
+        "cloudformation:DeleteResource",
+        "cloudformation:ListResources",
+        "cloudformation:GetResourceRequestStatus",
+        "cloudformation:ListResourceRequests"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaSnsNotificationTopic",
+      "Effect": "Allow",
+      "Action": [
+        "sns:CreateTopic", 
+        "sns:DeleteTopic", 
+        "sns:GetTopicAttributes", 
+        "sns:SetTopicAttributes", 
+        "sns:TagResource", 
+        "sns:ListTagsForResource", 
+        "sns:Subscribe", 
+        "sns:Unsubscribe", 
+        "sns:GetSubscriptionAttributes"
+        ],
+      "Resource": "arn:aws:sns:*:*:*"
+    },
+    {
+      "Sid": "ManageCatenaSqsNotificationQueue",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:CreateQueue", 
+        "sqs:DeleteQueue", 
+        "sqs:GetQueueAttributes", 
+        "sqs:SetQueueAttributes", 
+        "sqs:TagQueue", 
+        "sqs:ListQueueTags", 
+        "sqs:GetQueueUrl", 
+        "sqs:AddPermission"
+      ],
+      "Resource": "arn:aws:sqs:*:*:*"
+    },
+    {
+      "Sid": "ManageCatenaGameLiftMatchmakingRuleSets",
+      "Effect": "Allow",
+      "Action": [
+        "gamelift:CreateMatchmakingRuleSet", 
+        "gamelift:DeleteMatchmakingRuleSet", 
+        "gamelift:DescribeMatchmakingRuleSets", 
+        "gamelift:TagResource", 
+        "gamelift:ListTagsForResource"
+        ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaGameLiftMatchmakingConfigurations",
+      "Effect": "Allow",
+      "Action": [
+        "gamelift:CreateMatchmakingConfiguration", 
+        "gamelift:UpdateMatchmakingConfiguration", 
+        "gamelift:DeleteMatchmakingConfiguration", 
+        "gamelift:DescribeMatchmakingConfigurations"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ManageCatenaFlexMatchRuntimePolicy",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreatePolicy", 
+        "iam:DeletePolicy", 
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion", 
+        "iam:ListPolicyVersions",
+        "iam:CreatePolicyVersion", 
+        "iam:DeletePolicyVersion",
+        "iam:TagPolicy", 
+        "iam:ListEntitiesForPolicy"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:policy/*catena-flexmatch-runtime-policy"
+    },
+    {
+      "Sid": "ManageCatenaFlexMatchRuntimeUser",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateUser", 
+        "iam:DeleteUser", 
+        "iam:GetUser", 
+        "iam:TagUser",
+        "iam:AttachUserPolicy", 
+        "iam:DetachUserPolicy", 
+        "iam:ListAttachedUserPolicies",
+        "iam:ListUserPolicies", 
+        "iam:ListGroupsForUser", 
+        "iam:ListUserTags"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:user/*catena-flexmatch-runtime"
+    }
+  ]
+}
+```
+This policy is setup to help deploy FlexMatch to AWS. These SIDs allow us to provision FlexMatch resources. We are using `CatenaDeploymentPolicy` for Deploy time permissions.
+
+Here is the breakdown of the deployment SIDs:
+
+| SID                          | Purpose                                 | 
+|--------------------------------------|-----------------------------------------|
+| `ManageCatenaSnsNotificationTopic` | 	Create and configure the SNS topic FlexMatch uses to publish matchmaking events | 
+| `ManageCatenaSqsNotificationQueue` | 	Create and configure the SQS queue subscribed to that topic, which Catena polls for matchmaking updates |                                            |
+| `ManageCatenaGameLiftMatchmakingRuleSets` | 	Create/manage the GameLift rule sets defining team structure and match sizing|
+| `ManageCatenaGameLiftMatchmakingConfigurations` | 	Create/manage the GameLift matchmaking configurations that expose matchmaking to players  | 
+| `ManageCatenaFlexMatchRuntimePolicy` | 		Create, read, version, tag, and delete the FlexMatch runtime IAM policy  | 
+| `CloudControlApiForGameLiftResources` | 		Create, read, update, delete, and poll the status of resources managed through AWS Cloud Control API. Terraforms awscc provider routes all operations through Cloud Control.  | 
+| `ManageCatenaFlexMatchRuntimeUser` | 		Create, read, tag, delete, and manage policy attachments for the FlexMatch runtime IAM user. Deployments outside of ec2 have no instance role so this allows terraform to create one.  | 
+
+4. Name the policy `CatenaDeploymentPolicy`
+
+5. Got to `IAM Users` and create a new user called `catena_deployment`
+
+6. Select Attach Policy, search for the newly created `CatenaDeploymentPolicy`
+
+7. Generate an access key under `Security Credentials` -> `Access Keys` -> `Create Access Key` -> `Third Party Service`
+
+8. Make note of your Access Key and Secret Access Key. We will use these in the next step to configure our `catena_deploy` cli profile for deployment.
+
+#### 2c. Install Dependencies
+
+##### AWS CLI
+
+{% partial file="/_partials/aws/install-aws-cli.md" variables={
+    profile_name: "catena_deploy"
+} /%}
+
+### 3. Configure FlexMatch
+Now that you have everything prepped, it's time to configure FlexMatch in your AWS account. We will be using Terraform to configure the various components necessary for FlexMatch to operate. These include:
+
+**Matchmaking Ruleset(s)**
+
+[FlexMatch Rulesets](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-rulesets.html) define your game's team structure, size, and how to group players together for the best possible match.
+
+**Matchmaking Configuration(s)**
+
+[FlexMatch Configurations](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-create-configuration.html) expose matchmaking functionality to the outside world. These are how Catena makes matchmaking requests to AWS.
+
+**Simple Notification Service (SNS) Topic**
+
+[AWS SNS](https://aws.amazon.com/sns/) gives FlexMatch a place to post matchmaking events as they occur (i.e. match created).
+
+**Simple Queue Service (SQS) Queue**
+
+[AWS SQS](https://aws.amazon.com/sqs/) gives applications a way to subscribe to events that are sent to SNS topics. This is how Catena listens for matchmaking events for specific matchmaking tickets.
+
+#### 3a. Provision Resources
+1. Navigate to the Catena Infrastructure repository you cloned earlier.
+2. Navigate to the `aws/flex-match/` directory
+3. Initialize Terraform
+
+```bash
+terraform init
+```
+
+4. If you would like to customize the matchmaking queues that are available, edit the `matchmaking_queues` variable in `variables.tf`. For every queue name, you will need to define a corresponding ruleset in the `rule_sets/` directory. For more information on rule sets, refer to the [match rulesets](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-rulesets.html) documentation from Amazon.
+
+5. (Optional) Run a Terraform plan. This will preview all of the AWS resources that are about to be provisioned.
+
+```bash
+terraform plan
+```
+
+6. Run a Terraform apply. This will preview all of the AWS resource that are about to be provisioned, and prompt you if you'd like to proceed.
+
+```bash
+terraform apply
+```
+
+You should see a long list of output, with something resembling the following code block at the end.
+
+_Note: This is just example output._
+
+```bash
+Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+sqs_queue_url = "https://sqs.us-east-1.amazonaws.com/000000000000/matchmaking-events"
+flexmatch_runtime_user_name = "my_workspace_catena_flexmatch_runtime_policy"
+```
+
+7. Keep note of the `sqs_queue_url` and `flexmatch_runtime_user_name` that it outputs, as these will be used to configure your running instance of Catena.
+
+You should now have FlexMatch resources deployed. This also created a runtime IAM user and Policy for FlexMatch. This policy will allow us to go through the matchmaking process. Here is a breakdown of the SIDs we defined:
+
+| SID                          | Purpose                                 | 
+|--------------------------------------|-----------------------------------------|
+| `CatenaRuntimeGameLiftMatchmaking` | Lets running Catena application start, stop, and check matchmaking status via GameLift | 
+| `CatenaRuntimeSqsNotifications` | Lets the running application read and acknowledge matchmaking event messages from the FlexMatch notification queue |  
+
+#### 3b. Setup runtime credentials
+
+Now that we have our runtime user, we have to setup our Catena instance to actually use the user
+
+1. Log into your AWS account
+
+2. Navigate to `IAM` -> `IAM Users`
+
+3. Find and select the user from the previous output at `flexmatch_runtime_user_name`, that was the generated user
+
+4. Generate an access key under `Security Credentials` -> `Access Keys` -> `Create Access Key` -> `Third Party Service`
+
+5. Make note of your Access Key and Secret Access Key. We will use these to configure a `catena_runtime` cli profile for making matchmaking requests.
+
+6. On the machine you have Catena running on, you will need to install the AWS Cli as we did earlier
+
+{% partial file="/_partials/aws/install-aws-cli.md" variables={
+    profile_name: "catena_runtime"
+} /%}
+
+Once finished, your catena instance should now be authenticated to make matchmaking requests.
+
+#### 3b. Configure Catena
+Once you have your resources provisioned, you can configure Catena. Catena is configured using appsettings files in `catena-tools-core`. You will need the following items for Catena to work with FlexMatch:
+
+```json
+{
+    "Catena": {
+        ...
+        "Matchmaker": {
+            "FlexMatch": {
+                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
+                "GameLiftConfig": {
+                    "Profile": "<your_aws_profile_from_aws_cli>",
+                    "Region": "<your_aws_region_from_aws_cli>"
+                }
+            }
+        }
+        ...
+    },
+    "PreferredImplementations": {
+        ...
+        "ICatenaMatchmaker": "!AwsFlexMatch"
+        ...
+    }
+}
+```
+
+Alternatively, you can expose your access key/secret key directly, though you _should not_ check these values into source control.
+
+```json
+{
+    "Catena": {
+        ...
+        "Matchmaker": {
+            "FlexMatch": {
+                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
+                "GameLiftConfig": {
+                    "AccessKey": "<your_aws_access_key>",
+                    "SecretKey": "<your_aws_secret_key>",
+                    "Region": "<your_aws_region_from_aws_cli>"
+                }
+            }
+        }
+        ...
+    },
+    "PreferredImplementations": {
+        ...
+        "ICatenaMatchmaker": "!AwsFlexMatch"
+        ...
+    }
+}
+```
+
+## What Next?
+{% partial file="/_partials/matchmaking/what-next.md" /%}

--- a/features/matchmaking/aws-flex-match.md
+++ b/features/matchmaking/aws-flex-match.md
@@ -18,6 +18,14 @@ If you would like to learn more about how Catena handles dedicated game servers,
 
 [AWS FlexMatch](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-intro.html), also known as "Amazon GameLift Servers FlexMatch" is Amazon's offering for matchmaking players.
 
+### A Note on AWS Service Limits and Costs
+
+GameLift matchmaking configurations and rule sets are subject to account-level quotas. If you plan to run many logical matchmaking queues, check your current limits in the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/gamelift/quotas/) before provisioning.
+
+FlexMatch also bills for usage, even in standalone mode with no GameLift-hosted servers involved — you're charged for matchmaking hours and player packages processed, not just for the AWS resources this guide provisions. See [FlexMatch pricing](https://aws.amazon.com/gamelift/servers/pricing/flexmatch-pricing/) for current rates, and note that costs scale with matchmaking traffic, not with how this deployment is configured.
+
+If you're deploying FlexMatch alongside a new `catena-core` EC2 deployment, also see the [service limits note in the AWS EC2 guide](../../installation/aws-ec2.md#a-note-on-aws-service-limits) — the same Elastic IP/VPC quotas apply there.
+
 ## Getting Started
 
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
@@ -28,28 +36,8 @@ To configure FlexMatch, you will also need to clone Catena's Infrastructure as C
 git clone git@github.com:CatenaTools/infrastructure.git
 ```
 
-### 2. Preparations
-
-#### 2a. Create an AWS Account
-{% partial file="/_partials/aws/create-an-aws-account.md" /%}
-
-#### 2b. Create Credentials
-{% partial file="/_partials/aws/create-credentials.md" variables={
-    iam_username: "catena_matchmaking"
-} /%}
-
-#### 2c. Install Dependencies
-
-##### AWS CLI
-{% partial file="/_partials/aws/install-aws-cli.md" variables={
-    profile_name: "catena_gamelift"
-} /%}
-
 ##### Terraform
 {% partial file="/_partials/aws/terraform.md" /%}
-
-### 3. Configure FlexMatch
-Now that you have everything prepped, it's time to configure FlexMatch in your AWS account. We will be using Terraform to configure the various components necessary for FlexMatch to operate. These include:
 
 **Matchmaking Ruleset(s)**
 
@@ -67,95 +55,6 @@ Now that you have everything prepped, it's time to configure FlexMatch in your A
 
 [AWS SQS](https://aws.amazon.com/sqs/) gives applications a way to subscribe to events that are sent to SNS topics. This is how Catena listens for matchmaking events for specific matchmaking tickets.
 
-#### 3a. Provision Resources
-1. Navigate to the Catena Infrastructure repository you cloned earlier.
-2. Navigate to the `aws/flex-match/` directory
-3. Initialize Terraform
-
-```bash
-terraform init
-```
-
-4. If you would like to customize the matchmaking queues that are available, edit the `matchmaking_queues` variable in `variables.tf`. For every queue name, you will need to define a corresponding ruleset in the `rule_sets/` directory. For more information on rule sets, refer to the [match rulesets](https://docs.aws.amazon.com/gamelift/latest/flexmatchguide/match-rulesets.html) documentation from Amazon.
-
-5. (Optional) Run a Terraform plan. This will preview all of the AWS resources that are about to be provisioned.
-
-```bash
-terraform plan
-```
-
-6. Run a Terraform apply. This will preview all of the AWS resource that are about to be provisioned, and prompt you if you'd like to proceed.
-
-```bash
-terraform apply
-```
-
-You should see a long list of output, with something resembling the following code block at the end.
-
-_Note: This is just example output._
-
-```bash
-Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
-
-Outputs:
-
-sqs_queue_url = "https://sqs.us-east-1.amazonaws.com/000000000000/matchmaking-events"
-```
-
-7. Keep note of the `sqs_queue_url` that it output, as it will be used to configure your running instance of Catena.
-
-#### 3b. Configure Catena
-Once you have your resources provisioned, you can configure Catena. Catena is configured using appsettings files in `catena-tools-core`. You will need the following items for Catena to work with FlexMatch:
-
-```json
-{
-    "Catena": {
-        ...
-        "Matchmaker": {
-            "FlexMatch": {
-                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
-                "GameLiftConfig": {
-                    "Profile": "<your_aws_profile_from_aws_cli>",
-                    "Region": "<your_aws_region_from_aws_cli>"
-                }
-            }
-        }
-        ...
-    },
-    "PreferredImplementations": {
-        ...
-        "ICatenaMatchmaker": "!AwsFlexMatch"
-        ...
-    }
-}
-```
-
-Alternatively, you can expose your access key/secret key directly, though you _should not_ check these values into source control.
-
-```json
-{
-    "Catena": {
-        ...
-        "Matchmaker": {
-            "FlexMatch": {
-                "SQSQueueUrl": "<your_sqs_url_from_terraform_output>",
-                "GameLiftConfig": {
-                    "AccessKey": "<your_aws_access_key>",
-                    "SecretKey": "<your_aws_secret_key>",
-                    "Region": "<your_aws_region_from_aws_cli>"
-                }
-            }
-        }
-        ...
-    },
-    "PreferredImplementations": {
-        ...
-        "ICatenaMatchmaker": "!AwsFlexMatch"
-        ...
-    }
-}
-```
-
 ## How The Matchmaker Works
 
 ### Tickets
@@ -169,4 +68,4 @@ As **matchmaking tickets** progress through Catena and ultimately through FlexMa
 {% partial file="/_partials/matchmaking/events.md" /%}
 
 ## What Next?
-{% partial file="/_partials/matchmaking/what-next.md" /%}
+{% partial file="/_partials/matchmaking/fresh-new.md" /%}

--- a/installation/aws-ec2.md
+++ b/installation/aws-ec2.md
@@ -15,8 +15,26 @@ Starting from scratch, deploying Catena to AWS on a single EC2 instance is estim
 ## What is an Amazon VPC?
 [VPC](https://aws.amazon.com/vpc/) stands for Virtual Private Cloud. It is an Amazon service that allows users to create isolated virtual networks within the Amazon Web Services (AWS) cloud. It provides control over network configuration, including IP address management, subnets, and security settings for AWS resources.
 
+## What is an Elastic IP?
+An [Elastic IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) is a static, public IPv4 address that stays fixed even if the EC2 instance behind it is stopped, restarted, or replaced. This deployment uses one so your domain always resolves to the same address, regardless of what happens to the underlying instance.
+
+## A Note on AWS Service Limits
+
+New AWS accounts have default quotas you might run into over time, especially if you're running multiple parallel deployments.
+
+- **Elastic IPs: quota of 5 per Region by default** for any new account. If we try a 6th parallel deployment in the same account/region, it will fail to provision until we either request an increase or free up an existing EIP. You can request a higher quota anytime via the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas/). **Note:** Quota increase is free, however you will be charged for each allocated EIP.
+- **VPCs: 5 per Region by default**, also adjustable with no direct per-VPC charge.
+- **On-Demand EC2 vCPUs**: new accounts often start with a low default. Check your account's current value before choosing a larger instance size than the default `t2.small`. `t2.small` itself is not in the free tier so be aware of that cost before deployment.
+
+Check your current usage and request increases in advance via the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/ec2/quotas/) — approval isn't always instant.
+
+
 ## Where can Catena be Deployed?
 Catena can be deployed into any AWS region that supports Amazon EC2 instances running in an Amazon VPC. AWS Regions that support both Amazon EC2 and Amazon VPC include US East (N. Virginia), US West (N. California), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), and South America (São Paulo).
+
+    {% admonition type="info" %}
+    **Running this guide as instructed will incur charges.** Free Tier EC2 coverage applies only to `t2.micro` instance sizes. We recommended `t2.small` for this deployment. `t2.small` and any larger size incurs cost from the first hour it runs. Budget accordingly if you're running this alongside other AWS usage, and tear down deployments you're no longer using (`terraform destroy`) rather than leaving them running idle
+    {% /admonition %}
 
 ## Deployment Instructions
 {% partial file="/_partials/install-catena/obtain-catena-source.md" /%}
@@ -37,6 +55,8 @@ git clone git@github.com:CatenaTools/infrastructure.git
 {% partial file="/_partials/aws/examples-catena-deploy-policy.md" /%}
 
 #### 2c. Create Credentials
+We are going to setup the catena_deployment IAM user. The catena_deployment user will be used by Terraform to provision your AWS infrastructure — it's only used at deploy/update time and will never be used by the running Catena application.
+
 > **Do not use the AWS account root user!**
 >
 > Do not use the AWS account root user to deploy or operate Catena. The root user has unrestricted access to all AWS services and resources in the account, including billing and account-level settings. Catena does not require root user privileges for deployment or operation.
@@ -148,7 +168,7 @@ The default value set, t2.small (2 vCPU / 2 GB RAM), is suitable for development
 | `t2.small` (default)                       | 2 vCPU / 2 GB                          | Development, staging, small production workloads                                    |
 | `t2.medium`                           | 2 vCPU / 4 GB                             | Early production with moderate concurrent sessions                                              |
 | `t2.large`           | 2 vCPU / 8 GB                | Higher player counts or additional plugins/modules                                          |
-
+**Remember** None of these sizes come with the free AWS tier, running with the default value will incur charges here
 
 If you consistently exhaust CPU credits (visible via the `CPUCreditBalance` CloudWatch metric once deployed), move up a size.
 

--- a/sidebars.yaml
+++ b/sidebars.yaml
@@ -145,8 +145,13 @@
           items:
             - page: features/matchmaking/custom-strategies-hooks.md
               label: Custom Strategies/Hooks
-        - page: features/matchmaking/aws-flex-match.md
-          label: AWS FlexMatch
+        - group: AWS Flex Match
+          page: features/matchmaking/aws-flex-match.md
+          items: 
+            - page: features/matchmaking/aws-flex-match-existing-deployment.md
+              label: Exisitng AWS Deployment
+            - page: features/matchmaking/aws-flex-match-new-deployment.md
+              label: First AWS Deployment
     - page: features/parties/index.md
       label: "Parties"
     - page: features/twitch-integration/index.md


### PR DESCRIPTION
DESC-005: Deployment guide describes the purpose of each AWS Identity and Access Management (IAM) role and IAM policy the user is instructed to create.

Labeling the catena_deploy and catena_matchmaking IAM users. Added break down on different SIDs used in catena_deployment policy.